### PR TITLE
chore: upgrade groovy version to 3 with JDK17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
           # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'medium'
           # filters:
             # branches:
@@ -95,7 +95,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   release_dry_run:
@@ -116,7 +116,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
   # ---
   # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
@@ -139,7 +139,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
   # ---
   # The 6 Workflows Below are there to perform a "Standalone Release" and "replay" a "Standalone Release" :
@@ -163,7 +163,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   standalone_release_dry_run:
@@ -184,7 +184,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   standalone_nexus_staging:
@@ -224,7 +224,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
       - gravitee/d_standalone_nexus_staging:
           name: standalone_nexus_staging
@@ -237,7 +237,7 @@ workflows:
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   standalone_release_replay:
@@ -259,7 +259,7 @@ workflows:
           gio_release_version: << pipeline.parameters.replayed_release >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   standalone_release_replay_dry_run:
@@ -281,7 +281,7 @@ workflows:
           gio_release_version: << pipeline.parameters.replayed_release >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
   standalone_nexus_staging_replay:
@@ -322,7 +322,7 @@ workflows:
           gio_release_version: << pipeline.parameters.replayed_release >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
       - gravitee/d_standalone_nexus_staging_replay:
           name: standalone_nexus_staging_replay
@@ -336,7 +336,7 @@ workflows:
           gio_release_version: << pipeline.parameters.replayed_release >>
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
-          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          # container_gun_image_tag: '17.0.1'
           container_size: 'large'
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-gateway-buffer.version>1.18.3</gravitee-gateway-buffer.version>
         <gravitee-policy-api.version>1.9.0</gravitee-policy-api.version>
         <gravitee-common.version>1.17.2</gravitee-common.version>
-        <groovy.version>2.5.14</groovy.version>
+        <groovy.version>3.0.9</groovy.version>
         <groovy-sandbox.version>1.27</groovy-sandbox.version>
         <commons-lang3.version>3.11</commons-lang3.version>
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
@@ -103,6 +103,12 @@
             <groupId>org.kohsuke</groupId>
             <artifactId>groovy-sandbox</artifactId>
             <version>${groovy-sandbox.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -164,6 +170,16 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
@@ -15,25 +15,17 @@
  */
 package io.gravitee.policy.groovy.sandbox;
 
-import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
-import static org.codehaus.groovy.ast.tools.GeneralUtils.propX;
-
 import groovy.lang.Binding;
 import groovy.lang.GroovyCodeSource;
 import groovy.lang.GroovyShell;
 import groovy.lang.Script;
-import groovy.transform.ThreadInterrupt;
-import groovy.transform.TimedInterrupt;
 import io.gravitee.policy.groovy.GroovyPolicy;
 import io.gravitee.policy.groovy.utils.Sha1;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import org.apache.groovy.json.internal.FastStringUtils;
-import org.apache.groovy.util.Maps;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
 import org.codehaus.groovy.control.customizers.SecureASTCustomizer;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.kohsuke.groovy.sandbox.GroovyInterceptor;

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
@@ -250,6 +250,12 @@ public class SecuredResolver {
             return true;
         }
 
+        if (object instanceof String && "plus".equals(methodName)) {
+            // String.plus(String).
+            resolved.put(key, true);
+            return true;
+        }
+
         Class<?>[] argumentClasses = getClasses(methodArgs);
 
         boolean methodAllowed =


### PR DESCRIPTION
This is a draft for the groovy policy plugin.

⚠️ Please create an issue when this  isrelevant

Notes:
- Groovy 2 not supported by Java17, moving to 3.X
- `class java.lang.String plus java.lang.String` did not work anymore, patched
- Super calls to constructor / methods fails

![image](https://user-images.githubusercontent.com/8531515/146383163-869d1105-77ee-4dde-b247-fdd64ee94d35.png)

The stacktrace: 

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
b19aa8c1972b85e6ff57f86bd599410edd3e2fb9: -1: Cannot reference 'toArray' before supertype constructor has been called. Possible causes:
You attempted to access an instance field, method, or property.
You attempted to construct a non-static inner class.
. At [-1:-1] b19aa8c1972b85e6ff57f86bd599410edd3e2fb9 @ line -1, column -1.
1 error


	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:295)
	at org.codehaus.groovy.control.CompilationUnit$IPrimaryClassNodeOperation.doPhaseOperation(CompilationUnit.java:984)
	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:671)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:635)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:389)
	at groovy.lang.GroovyClassLoader.lambda$parseClass$3(GroovyClassLoader.java:332)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.compute(StampedCommonCache.java:163)
	at org.codehaus.groovy.runtime.memoize.StampedCommonCache.getAndPut(StampedCommonCache.java:154)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:330)
	at io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.lambda$getOrCreate$0(SecuredGroovyShell.java:101)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.getOrCreate(SecuredGroovyShell.java:97)
	at io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.evaluate(SecuredGroovyShell.java:83)
	at io.gravitee.policy.groovy.sandbox.SecuredGroovyShellTest.superConstructorAllowed(SecuredGroovyShellTest.java:691)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
...

```

This is blocking AM and APIM since they will run with a Java17 runtime