### PR TITLE
fix: make header accessor return an iterable instead of a string

### DIFF
--- a/src/main/java/io/gravitee/policy/groovy/model/HeaderMapAdapter.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/HeaderMapAdapter.java
@@ -16,15 +16,18 @@
 package io.gravitee.policy.groovy.model;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class HeaderMapAdapter implements Map<String, String> {
+public class HeaderMapAdapter implements Map<String, List<String>> {
 
     private final HttpHeaders headers;
 
@@ -53,26 +56,32 @@ public class HeaderMapAdapter implements Map<String, String> {
     }
 
     @Override
-    public String get(Object key) {
-        return headers.get((String) key);
+    public List<String> get(Object key) {
+        return headers.getAll((String) key);
     }
 
-    @Override
-    public String put(String key, String value) {
-        String oldValue = get(key);
-        headers.set(key, value);
+    public List<String> put(String key, String value) {
+        List<String> oldValue = get(key);
+        headers.set(key, List.of(value));
         return oldValue;
     }
 
     @Override
-    public String remove(Object key) {
-        String oldValue = get(key);
+    public List<String> put(String key, List<String> value) {
+        List<String> oldValue = get(key);
+        headers.set(key, new ArrayList<>(value));
+        return oldValue;
+    }
+
+    @Override
+    public List<String> remove(Object key) {
+        List<String> oldValue = get(key);
         headers.remove((String) key);
         return oldValue;
     }
 
     @Override
-    public void putAll(Map<? extends String, ? extends String> m) {
+    public void putAll(Map<? extends String, ? extends List<String>> m) {
         throw new IllegalStateException();
     }
 
@@ -87,12 +96,12 @@ public class HeaderMapAdapter implements Map<String, String> {
     }
 
     @Override
-    public Collection<String> values() {
+    public Collection<List<String>> values() {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Entry<String, String>> entrySet() {
+    public Set<Entry<String, List<String>>> entrySet() {
         throw new IllegalStateException();
     }
 }

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -28,6 +28,7 @@ class io.gravitee.common.util.URIUtils
 class io.gravitee.gateway.api.ExecutionContext
 class io.gravitee.policy.groovy.model.ContentAwareRequest
 class io.gravitee.policy.groovy.model.ContentAwareResponse
+class io.gravitee.policy.groovy.model.HeaderMapAdapter
 class io.gravitee.policy.groovy.PolicyResult
 class io.gravitee.policy.groovy.PolicyResult$State
 class io.gravitee.policy.groovy.utils.AttributesBasedExecutionContext

--- a/src/test/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShellTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShellTest.java
@@ -17,22 +17,14 @@ package io.gravitee.policy.groovy.sandbox;
 
 import static io.gravitee.policy.groovy.sandbox.SecuredResolver.WHITELIST_LIST_KEY;
 import static io.gravitee.policy.groovy.sandbox.SecuredResolver.WHITELIST_MODE_KEY;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
-import io.gravitee.el.TemplateEngine;
-import java.util.concurrent.ConcurrentHashMap;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.Environment;
-import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.mock.env.MockEnvironment;
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7810
https://github.com/gravitee-io/issues/issues/7811

**Description**

Fix the HeaderMapAdapter to not create a regression with the behavior previous from 3.15


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.1-groovy-headers-error-3-17-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.2.1-groovy-headers-error-3-17-SNAPSHOT/gravitee-policy-groovy-2.2.1-groovy-headers-error-3-17-SNAPSHOT.zip)
  <!-- Version placeholder end -->
