### PR TITLE
fix: whitelist gateway-api HttpHeaders

### DIFF
--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -26,6 +26,7 @@ class io.gravitee.common.util.Maps
 class io.gravitee.common.util.MultiValueMap
 class io.gravitee.common.util.URIUtils
 class io.gravitee.gateway.api.ExecutionContext
+class io.gravitee.gateway.api.http.HttpHeaders
 class io.gravitee.policy.groovy.model.ContentAwareRequest
 class io.gravitee.policy.groovy.model.ContentAwareResponse
 class io.gravitee.policy.groovy.model.HeaderMapAdapter


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.2-issues-7812-retro-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.2.2-issues-7812-retro-headers-SNAPSHOT/gravitee-policy-groovy-2.2.2-issues-7812-retro-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
