### PR TITLE
scheme() method returns the local adress

### DIFF
--- a/src/main/java/io/gravitee/policy/groovy/model/ContentAwareRequest.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/ContentAwareRequest.java
@@ -239,4 +239,8 @@ public class ContentAwareRequest implements Request {
     public String host() {
         return request.host();
     }
+    
+    public String getHost() {
+        return this.host();
+    }
 }

--- a/src/main/java/io/gravitee/policy/groovy/model/ContentAwareRequest.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/ContentAwareRequest.java
@@ -174,7 +174,7 @@ public class ContentAwareRequest implements Request {
 
     @Override
     public String scheme() {
-        return request.localAddress();
+        return request.scheme();
     }
 
     public String getScheme() {


### PR DESCRIPTION
**Description**
Fix scheme() and getScheme() methods returning the local adresse instead of the http/https scheme
Added a getHost() getter so that the "request.host" groovy expression is correctly resolved (similar to other attributes)