### PR TITLE
fix: add policy result key to readme 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,14 +55,18 @@ Some variables are automatically bound to the Groovy script to allow users to us
 
 |===
 
-You can interrupt request or response processing by setting the result state to `FAILURE`, providing an HTTP
-status code and a message (this is not mandatory, as the default status is `500 - internal server error`).
+Request or response processing can be interrupted by setting the result state to `FAILURE`.
+By default, it will throw a `500 - internal server error` but you can override this behavior with the following properties:
+- `code`: An HTTP status code
+- `error`: The error message
+- `key`: The key of a response template
 
 [source, groovy]
 ----
 import io.gravitee.policy.groovy.PolicyResult.State
 
 if (request.headers.containsKey('X-Gravitee-Break')) {
+    result.key = 'RESPONSE_TEMPLATE_KEY';
     result.state = State.FAILURE;
     result.code = 500
     result.error = 'Stop request processing due to X-Gravitee-Break header'
@@ -76,6 +80,7 @@ To customize the error sent by the policy:
 [source, groovy]
 ----
 import io.gravitee.policy.groovy.PolicyResult.State
+result.key = 'RESPONSE_TEMPLATE_KEY';
 result.state = State.FAILURE;
 result.code = 400
 result.error = '{"error":"My specific error message","code":"MY_ERROR_CODE"}'


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1759
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.4.1-apim-1759-groovy-failure-2-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.4.1-apim-1759-groovy-failure-2-SNAPSHOT/gravitee-policy-groovy-2.4.1-apim-1759-groovy-failure-2-SNAPSHOT.zip)
  <!-- Version placeholder end -->
