### PR TITLE
fix: add request and response to message phases

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -7,4 +7,4 @@ type=policy
 category=others
 icon=groovy.svg
 proxy=REQUEST,RESPONSE
-message=MESSAGE_REQUEST,MESSAGE_RESPONSE
+message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-1630

The feat commit forgot the REQUEST,RESPONSE phases for message 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.1-fix-message-scopes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.5.1-fix-message-scopes-SNAPSHOT/gravitee-policy-groovy-2.5.1-fix-message-scopes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
