### PR TITLE
fix: do not write body if onRequest/Response only

### DIFF
--- a/src/main/java/io/gravitee/policy/groovy/configuration/GroovyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/groovy/configuration/GroovyPolicyConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.policy.groovy.configuration;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.gravitee.policy.api.PolicyConfiguration;
@@ -48,23 +47,6 @@ public class GroovyPolicyConfiguration implements PolicyConfiguration {
     private String onRequestContentScript;
 
     private String onResponseContentScript;
-
-    /**
-     * This getter is overridden for backward compatibility.
-     *
-     * As there is no way to know if a v3 script would read the content or not, we assume that it will
-     * if the new script property is empty (which ensures we are running for a v3 API).
-     *
-     * For v4 API, reading the content is an explicit configuration property.
-     *
-     * Not enabling it will result in the content not being loaded to run the script,
-     * which can improve performances if the script does not need it.
-     *
-     * @return whether the policy should read the content or not to run the script
-     */
-    public boolean isReadContent() {
-        return readContent || isBlank(script);
-    }
 
     /**
      * This getter is overridden for backward compatibility.

--- a/src/test/resources/apis/v3/api-pre-nocontent.json
+++ b/src/test/resources/apis/v3/api-pre-nocontent.json
@@ -1,0 +1,41 @@
+{
+    "id": "api-pre",
+    "name": "api-pre",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/api-pre",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/team",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": [],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [
+                {
+                    "name": "Groovy",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "groovy",
+                    "configuration": {
+                        "onRequestScript": "request.headers.'X-Phase' = 'on-request'"
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": []
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3201

**Description**

Before this PR, we considered that a V2 API always access to the request and the response content. But the impact was that the body of the request / response was set (even with an empty value) and so later we had the error

`java.lang.IllegalStateException: You must set the Content-Length header to be the total size of the message body BEFORE sending any data if you are not using HTTP chunked encoding.`

This PR adds a unit test and new if statements to determine if the API really has to access the content or not.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.2-apim-3201-fix-request-and-response-for-emulation-mode-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.5.2-apim-3201-fix-request-and-response-for-emulation-mode-SNAPSHOT/gravitee-policy-groovy-2.5.2-apim-3201-fix-request-and-response-for-emulation-mode-SNAPSHOT.zip)
  <!-- Version placeholder end -->
