### PR TITLE
fix: update logs sent on groovy script error

### DIFF
--- a/src/main/java/io/gravitee/policy/groovy/GroovyPolicy.java
+++ b/src/main/java/io/gravitee/policy/groovy/GroovyPolicy.java
@@ -112,7 +112,7 @@ public class GroovyPolicy {
                             }
                         } catch (Throwable t) {
                             logger.error("Unable to run Groovy script", t);
-                            throw new TransformationException("Unable to run Groovy script: " + t.getMessage(), t);
+                            throw new TransformationException("Internal Server Error");
                         }
                         return null;
                     }
@@ -168,7 +168,7 @@ public class GroovyPolicy {
                             }
                         } catch (Throwable t) {
                             logger.error("Unable to run Groovy script", t);
-                            throw new TransformationException("Unable to run Groovy script: " + t.getMessage(), t);
+                            throw new TransformationException("Internal Server Error");
                         }
                         return null;
                     }
@@ -222,7 +222,7 @@ public class GroovyPolicy {
                 }
             } catch (Throwable t) {
                 logger.error("Unable to run Groovy script", t);
-                policyChain.failWith(io.gravitee.policy.api.PolicyResult.failure(t.getMessage()));
+                policyChain.failWith(io.gravitee.policy.api.PolicyResult.failure("Internal Server Error"));
             }
         }
 

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyIntegrationTest.java
@@ -146,4 +146,88 @@ public class GroovyPolicyIntegrationTest extends AbstractPolicyTest<GroovyPolicy
 
         wiremock.verify(0, postRequestedFor(urlPathEqualTo("/team")));
     }
+
+    @Test
+    @DeployApi("/apis/api-fail-parse-response-content.json")
+    void should_throw_exception_on_response_content(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("[{\"foo\", \"bar\"},\"bar\": \"baz\"]")));
+
+        client
+            .post("/test")
+            .rxSend()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    assertThat(response.bodyAsString()).contains("Internal Server Error");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @Test
+    @DeployApi("/apis/api-fail-parse-request-content.json")
+    void should_throw_exception_on_request_content(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("")));
+
+        client
+            .post("/test")
+            .rxSendJson("[{\"foo\": \"bar\"}, {\"bar\": \"baz\"}]")
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    assertThat(response.bodyAsString()).contains("Internal Server Error");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @Test
+    @DeployApi("/apis/api-fail-execute-response-script.json")
+    void should_throw_exception_on_response(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("")));
+
+        client
+            .post("/test")
+            .rxSend()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    assertThat(response.bodyAsString()).contains("Internal Server Error");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @Test
+    @DeployApi("/apis/api-fail-execute-request-script.json")
+    void should_throw_exception_on_request(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("")));
+
+        client
+            .post("/test")
+            .rxSend()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(500);
+                    assertThat(response.bodyAsString()).contains("Internal Server Error");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+    }
 }

--- a/src/test/resources/apis/api-fail-execute-request-script.json
+++ b/src/test/resources/apis/api-fail-execute-request-script.json
@@ -1,0 +1,44 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Groovy",
+          "description": "",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "scope": "REQUEST",
+            "onRequestScript": "def foo= nes azdazdaa();"
+          }
+        }
+      ],
+      "post": []
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/api-fail-execute-response-script.json
+++ b/src/test/resources/apis/api-fail-execute-response-script.json
@@ -1,0 +1,44 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [],
+      "post": [
+        {
+          "name": "Groovy",
+          "description": "",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "scope": "RESPONSE",
+            "onResponseScript": "def foo= azkcaznc();"
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/api-fail-parse-request-content.json
+++ b/src/test/resources/apis/api-fail-parse-request-content.json
@@ -1,0 +1,44 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Groovy",
+          "description": "",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "scope": "REQUEST",
+            "onRequestContentScript": "import groovy.json.JsonSlurper\nimport groovy.json.JsonOutput\n\ndef jsonSlurper = new JsonSlurper()\ndef content = jsonSlurper.parseText(response.content)\nreturn JsonOutput.toJson(content)"
+          }
+        }
+      ],
+      "post": []
+    }
+  ],
+  "resources": []
+}

--- a/src/test/resources/apis/api-fail-parse-response-content.json
+++ b/src/test/resources/apis/api-fail-parse-response-content.json
@@ -1,0 +1,44 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [],
+      "post": [
+        {
+          "name": "Groovy",
+          "description": "",
+          "enabled": true,
+          "policy": "groovy",
+          "configuration": {
+            "scope": "RESPONSE",
+            "onResponseContentScript": "import groovy.json.JsonSlurper\nimport groovy.json.JsonOutput\n\ndef jsonSlurper = new JsonSlurper()\ndef content = jsonSlurper.parseText(response.content)\nreturn JsonOutput.toJson(content)"
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3795

**Description**

update logs sent on groovy script error to avoid to leak information. This fix is only for apim 3.20.x and is not present on the version 2.5.x of the plugin

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.4.3-apim-3795-groovy-logs-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.4.3-apim-3795-groovy-logs-SNAPSHOT/gravitee-policy-groovy-2.4.3-apim-3795-groovy-logs-SNAPSHOT.zip)
  <!-- Version placeholder end -->
