### PR TITLE
fix: avoid blocking eventloop when compiling

### DIFF
--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
@@ -34,10 +34,12 @@ import io.gravitee.policy.groovy.configuration.GroovyPolicyConfiguration;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeTransformer;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,6 +94,7 @@ class GroovyPolicyTest {
         policy.onRequest(ctx).test().assertNoValues();
 
         ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
             .assertError(error -> {
                 assertThat(error).isInstanceOf(InterruptionFailureException.class);
                 InterruptionFailureException failureException = (InterruptionFailureException) error;
@@ -112,6 +115,7 @@ class GroovyPolicyTest {
         policy.onRequest(ctx).test().assertNoValues();
 
         ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
             .assertError(error -> {
                 assertThat(error).isInstanceOf(InterruptionFailureException.class);
                 InterruptionFailureException failureException = (InterruptionFailureException) error;
@@ -131,7 +135,10 @@ class GroovyPolicyTest {
         when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
         policy.onRequest(ctx).test().assertNoValues();
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         verify(ctx, times(1)).setAttribute("count", 100);
     }
@@ -143,7 +150,10 @@ class GroovyPolicyTest {
         when(response.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
         policy.onResponse(ctx).test().assertNoValues();
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         verify(ctx, times(1)).setAttribute("count", 100);
     }
@@ -158,7 +168,10 @@ class GroovyPolicyTest {
         var headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         assertThat(headers.get("x-context")).isEqualTo("test");
     }
@@ -173,7 +186,10 @@ class GroovyPolicyTest {
         var headers = HttpHeaders.create();
         when(response.headers()).thenReturn(headers);
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         assertThat(headers.get("x-context")).isEqualTo("test");
     }
@@ -188,7 +204,10 @@ class GroovyPolicyTest {
         var headers = HttpHeaders.create().set("x-context", "test");
         when(request.headers()).thenReturn(headers);
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         assertThat(headers.size()).isZero();
     }
@@ -203,7 +222,10 @@ class GroovyPolicyTest {
         var headers = HttpHeaders.create().set("x-context", "test");
         when(response.headers()).thenReturn(headers);
 
-        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test().assertComplete().assertNoErrors();
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
 
         assertThat(headers.size()).isZero();
     }
@@ -217,7 +239,7 @@ class GroovyPolicyTest {
 
         var message = mock(Message.class);
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         verify(ctx, times(1)).setAttribute("count", 100);
     }
@@ -231,7 +253,7 @@ class GroovyPolicyTest {
 
         var message = mock(Message.class);
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         verify(ctx, times(1)).setAttribute("count", 100);
     }
@@ -244,7 +266,7 @@ class GroovyPolicyTest {
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.headers().get("x-context")).isEqualTo("test");
     }
@@ -257,7 +279,7 @@ class GroovyPolicyTest {
         when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageResponse(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.headers().get("x-context")).isEqualTo("test");
     }
@@ -270,7 +292,7 @@ class GroovyPolicyTest {
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.headers().size()).isZero();
     }
@@ -283,7 +305,7 @@ class GroovyPolicyTest {
         when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageResponse(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.headers().size()).isZero();
     }
@@ -296,7 +318,7 @@ class GroovyPolicyTest {
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.attributes()).containsEntry("count", 100);
     }
@@ -315,7 +337,7 @@ class GroovyPolicyTest {
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
 
-        onMessageCaptor.getValue().apply(message).test().assertComplete().assertNoErrors();
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.<String>attribute("wronglyBase64EncodedContent"))
             .isNotEqualTo(Base64.getEncoder().encodeToString(isoEncodedCharacter));


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4470

**Description**

This PR brings a few refactoring to allow pre-compiling Groovy scripts when the policy is instantiated. The compilation must not be performed on the event loop (scheduled on io). In case the script hasn't been compiled yet when a request is handled, the evaluation is scheduled on the io thread to avoid blocking the event loop. As it is costly, once the script is compiled, the subsequent executions are made on the event loop (nothing is supposed to block anymore).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.2-apim-4470-avoid-blocking-groovy-compilation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.6.2-apim-4470-avoid-blocking-groovy-compilation-SNAPSHOT/gravitee-policy-groovy-2.6.2-apim-4470-avoid-blocking-groovy-compilation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
