### PR TITLE
Add methods to access the binary content of messages

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -190,6 +190,11 @@ content.greeting = 'Hello Universe!'
 return JsonOutput.toJson(content)
 ----
 
+The content of a message can also be accessed directly:
+
+ - as a base64 string with `message.contentAsBase64`
+ - as an array of bytes with `message.contentAsByteArray`
+
 == Errors
 
 === Sandbox

--- a/src/main/java/io/gravitee/policy/groovy/model/message/BindableMessage.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/message/BindableMessage.java
@@ -19,6 +19,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.policy.groovy.model.BindableHttpHeaders;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -109,6 +110,14 @@ public class BindableMessage implements Message {
 
     public String getContent() {
         return message.content() == null ? "" : content().toString();
+    }
+
+    public String getContentAsBase64() {
+        return message.content() == null ? "" : Base64.getEncoder().encodeToString(message.content().getBytes());
+    }
+
+    public byte[] getContentAsByteArray() {
+        return message.content() == null ? new byte[0] : message.content().getBytes();
     }
 
     @Override

--- a/src/test/resources/io/gravitee/policy/groovy/get_message_binary_content.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/get_message_binary_content.groovy
@@ -1,0 +1,3 @@
+message.attributes.wronglyBase64EncodedContent = message.content.bytes.encodeBase64().toString()  // final value is not well encoded because of Charset transformation
+message.attributes.goodBase64Content = message.contentAsBase64
+message.attributes.byteArray = message.contentAsByteArray.toString()


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5260

**Description**

Add methods to access the binary content of messages
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.0-apim-5260-allow-to-access-binary-content-of-messages-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.6.0-apim-5260-allow-to-access-binary-content-of-messages-SNAPSHOT/gravitee-policy-groovy-2.6.0-apim-5260-allow-to-access-binary-content-of-messages-SNAPSHOT.zip)
  <!-- Version placeholder end -->
