### PR TITLE
Fix date parse error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-dateutil</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>groovy-sandbox</artifactId>
             <version>${groovy-sandbox.version}</version>

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
@@ -35,6 +35,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
+import org.apache.groovy.dateutil.extensions.DateUtilExtensions;
+import org.apache.groovy.dateutil.extensions.DateUtilStaticExtensions;
 import org.codehaus.groovy.runtime.DateGroovyMethods;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.EncodingGroovyMethods;
@@ -90,6 +92,8 @@ public class SecuredResolver {
         StringGroovyMethods.class,
         EncodingGroovyMethods.class,
         DateGroovyMethods.class,
+        DateUtilExtensions.class,
+        DateUtilStaticExtensions.class,
     };
 
     private static final List<String> ALLOWED_ARRAY_NATIVE_METHODS = Arrays.asList("getAt", "putAt", "getLength");

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -68,6 +68,9 @@ class java.util.List
 class java.util.Map
 class java.util.Queue
 class java.util.Random
+class org.codehaus.groovy.runtime.DateGroovyMethods
+class org.apache.groovy.dateutil.extensions.DateUtilExtensions
+class org.apache.groovy.dateutil.extensions.DateUtilStaticExtensions
 
 # Allows method signatures
 method groovy.json.JsonSlurper parseText java.lang.String
@@ -1174,6 +1177,7 @@ method org.codehaus.groovy.runtime.StringGroovyMethods tr java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence int
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpandLine java.lang.CharSequence int
+
 # Allows constructor signatures
 
 # Allows annotations

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -49,10 +49,16 @@ class java.math.BigDecimal
 class java.math.BigInteger
 class java.net.URLDecoder
 class java.net.URLEncoder
+class java.time.chrono.ChronoLocalDateTime
+class java.time.chrono.ChronoZonedDateTime
+class java.time.temporal.Temporal
+class java.time.temporal.TemporalAdjuster
 class java.time.format.DateTimeFormatter
+class java.time.Instant
 class java.time.LocalDate
 class java.time.LocalDateTime
 class java.time.ZonedDateTime
+class java.time.ZoneId
 class java.util.Calendar
 class java.util.Collection
 class java.util.Collections


### PR DESCRIPTION

**Description**

Some methods from Date and LocalDate, etc were not working properly.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.1-fix-date-parse-error-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.6.1-fix-date-parse-error-SNAPSHOT/gravitee-policy-groovy-2.6.1-fix-date-parse-error-SNAPSHOT.zip)
  <!-- Version placeholder end -->
