### PR TITLE
feat: support new OpenTelemetry feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-groovy</artifactId>
-    <version>2.6.2</version>
+    <version>3.0.0-archi-401-opentelemetry-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Policy - Groovy</name>
     <description>Run Groovy scripts at any stage of request or message processing</description>

--- a/src/main/java/io/gravitee/policy/groovy/model/BindableExecutionContext.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/BindableExecutionContext.java
@@ -30,7 +30,7 @@ import lombok.Value;
  * @author GraviteeSource Team
  */
 @Value
-public class BindableExecutionContext implements GenericExecutionContext {
+public class BindableExecutionContext {
 
     private static final String CONTEXT_DICTIONARIES_VARIABLE = "dictionaries";
 
@@ -44,17 +44,14 @@ public class BindableExecutionContext implements GenericExecutionContext {
             .lookupVariable(CONTEXT_DICTIONARIES_VARIABLE);
     }
 
-    @Override
     public GenericRequest request() {
         throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
     }
 
-    @Override
     public GenericResponse response() {
         throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
     }
 
-    @Override
     public Metrics metrics() {
         return executionContext.metrics();
     }
@@ -63,73 +60,31 @@ public class BindableExecutionContext implements GenericExecutionContext {
         return executionContext.metrics();
     }
 
-    @Override
-    public <T> T getComponent(Class<T> aClass) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
     public void setAttribute(String s, Object o) {
         executionContext.setAttribute(s, o);
     }
 
-    @Override
     public void putAttribute(String s, Object o) {
         executionContext.putAttribute(s, o);
     }
 
-    @Override
     public void removeAttribute(String s) {
         executionContext.removeAttribute(s);
     }
 
-    @Override
     public <T> T getAttribute(String s) {
         return executionContext.getAttribute(s);
     }
 
-    @Override
     public <T> List<T> getAttributeAsList(String s) {
         return executionContext.getAttributeAsList(s);
     }
 
-    @Override
     public Set<String> getAttributeNames() {
         return executionContext.getAttributeNames();
     }
 
-    @Override
     public <T> Map<String, T> getAttributes() {
         return executionContext.getAttributes();
-    }
-
-    @Override
-    public void setInternalAttribute(String s, Object o) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public void putInternalAttribute(String s, Object o) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public void removeInternalAttribute(String s) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public <T> T getInternalAttribute(String s) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public <T> Map<String, T> getInternalAttributes() {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public TemplateEngine getTemplateEngine() {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
     }
 }

--- a/src/main/java/io/gravitee/policy/groovy/utils/AttributesBasedExecutionContext.java
+++ b/src/main/java/io/gravitee/policy/groovy/utils/AttributesBasedExecutionContext.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class AttributesBasedExecutionContext implements ExecutionContext {
+public class AttributesBasedExecutionContext {
 
     private static final String CONTEXT_DICTIONARIES_VARIABLE = "dictionaries";
     private final ExecutionContext context;
@@ -42,53 +42,35 @@ public class AttributesBasedExecutionContext implements ExecutionContext {
             .lookupVariable(CONTEXT_DICTIONARIES_VARIABLE);
     }
 
-    @Override
     public Request request() {
         return context.request();
     }
 
-    @Override
     public Response response() {
         return context.response();
     }
 
-    @Override
-    public <T> T getComponent(Class<T> aClass) {
-        return context.getComponent(aClass);
-    }
-
-    @Override
     public void setAttribute(String s, Object o) {
         context.setAttribute(s, o);
     }
 
-    @Override
     public void removeAttribute(String s) {
         context.removeAttribute(s);
     }
 
-    @Override
     public Object getAttribute(String s) {
         return context.getAttribute(s);
     }
 
-    @Override
     public Enumeration<String> getAttributeNames() {
         return context.getAttributeNames();
     }
 
-    @Override
     public Map<String, Object> getAttributes() {
         return context.getAttributes();
     }
 
-    @Override
     public TemplateEngine getTemplateEngine() {
         return context.getTemplateEngine();
-    }
-
-    @Override
-    public Tracer getTracer() {
-        return context.getTracer();
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-401

**Description**

Migrate to the new `ExecutionContext` interface since Tracer has moved.
For security constraints, we've decided that there is no reason for Groovy binding to implement `ExecutionContext` interface.
Also, for security constraints, we must not expose internal components to Groovy script (which a already constrained by the allow list).

BREAKING CHANGE: tracer and components are no longer allowed for groovy context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-archi-401-opentelemetry-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/3.0.0-archi-401-opentelemetry-SNAPSHOT/gravitee-policy-groovy-3.0.0-archi-401-opentelemetry-SNAPSHOT.zip)
  <!-- Version placeholder end -->
