### PR TITLE
Archi 401 opentelemetry bump version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,15 +34,10 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>6.0.6</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.2.1</gravitee-gateway-api.version>
-        <gravitee-apim.version>4.1.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>3.3.0</gravitee-common.version>
-        <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
-        <gravitee-entrypoint-http-post.version>1.0.0</gravitee-entrypoint-http-post.version>
-        <gravitee-entrypoint-http-get.version>1.0.0</gravitee-entrypoint-http-get.version>
-        <gravitee-reactor-message.version>1.0.1</gravitee-reactor-message.version>
+        <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-entrypoint-http-post.version>2.0.0-alpha.1</gravitee-entrypoint-http-post.version>
+        <gravitee-entrypoint-http-get.version>2.0.0-alpha.1</gravitee-entrypoint-http-get.version>
+        <gravitee-reactor-message.version>5.0.0-alpha.2</gravitee-reactor-message.version>
         <groovy.version>3.0.19</groovy.version>
         <groovy-sandbox.version>1.27</groovy-sandbox.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
@@ -56,9 +51,9 @@
         <dependencies>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
-                <groupId>io.gravitee</groupId>
-                <artifactId>gravitee-bom</artifactId>
-                <version>${gravitee-bom.version}</version>
+                <groupId>io.gravitee.apim</groupId>
+                <artifactId>gravitee-apim-bom</artifactId>
+                <version>${gravitee-apim.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -70,28 +65,24 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.el</groupId>
             <artifactId>gravitee-expression-language</artifactId>
-            <version>${gravitee-expression-language.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/groovy/model/http/BindableHttpRequest.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/http/BindableHttpRequest.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.GenericRequest;
 import io.gravitee.gateway.reactive.api.context.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.policy.groovy.model.BindableHttpHeaders;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLSession;
@@ -219,6 +220,15 @@ public class BindableHttpRequest implements GenericRequest {
 
     public SSLSession getSslSession() {
         return sslSession();
+    }
+
+    @Override
+    public TlsSession tlsSession() {
+        return request.tlsSession();
+    }
+
+    public TlsSession getTslSession() {
+        return tlsSession();
     }
 
     @Override

--- a/src/main/java/io/gravitee/policy/groovy/utils/AttributesBasedExecutionContext.java
+++ b/src/main/java/io/gravitee/policy/groovy/utils/AttributesBasedExecutionContext.java
@@ -19,7 +19,6 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
-import io.gravitee.tracing.api.Tracer;
 import java.util.Enumeration;
 import java.util.Map;
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-archi-401-opentelemetry-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/3.0.0-archi-401-opentelemetry-SNAPSHOT/gravitee-policy-groovy-3.0.0-archi-401-opentelemetry-SNAPSHOT.zip)
  <!-- Version placeholder end -->
