### PR TITLE
fix: warning messages in logs for groovy classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>6.0.6</gravitee-bom.version>
         <gravitee-gateway-api.version>3.2.1</gravitee-gateway-api.version>
-        <gravitee-apim.version>4.1.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-apim.version>4.1.0</gravitee-apim.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>3.3.0</gravitee-common.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -35,7 +35,7 @@ class io.gravitee.policy.groovy.utils.AttributesBasedExecutionContext
 class io.gravitee.policy.groovy.model.BindableExecutionContext
 class io.gravitee.policy.groovy.model.http.BindableHttpRequest
 class io.gravitee.policy.groovy.model.http.BindableHttpResponse
-class io.gravitee.policy.groovy.model.http.BindableHttpHeaders
+class io.gravitee.policy.groovy.model.BindableHttpHeaders
 class io.gravitee.policy.groovy.model.message.BindableMessage
 class io.gravitee.policy.groovy.model.message.BindableMessageAttributes
 class java.lang.Double
@@ -71,6 +71,7 @@ class java.util.Random
 class org.codehaus.groovy.runtime.DateGroovyMethods
 class org.apache.groovy.dateutil.extensions.DateUtilExtensions
 class org.apache.groovy.dateutil.extensions.DateUtilStaticExtensions
+class java.lang.Byte
 
 # Allows method signatures
 method groovy.json.JsonSlurper parseText java.lang.String
@@ -1177,6 +1178,7 @@ method org.codehaus.groovy.runtime.StringGroovyMethods tr java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence int
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpandLine java.lang.CharSequence int
+method java.lang.String format java.lang.String java.lang.Object[]
 
 # Allows constructor signatures
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7782

**Description**

Updated pom.xml to use right apim-version and updated groovy-whitelist to remove warning messages

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.3-APIM-7782-fix-log-warnings-for-groovy-classes-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/2.6.3-APIM-7782-fix-log-warnings-for-groovy-classes-SNAPSHOT/gravitee-policy-groovy-2.6.3-APIM-7782-fix-log-warnings-for-groovy-classes-SNAPSHOT.zip)
  <!-- Version placeholder end -->
