### PR TITLE
fix: warning messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <gravitee-apim.version>4.6.0-SNAPSHOT</gravitee-apim.version>
-        <gravitee-entrypoint-http-post.version>2.0.0-alpha.1</gravitee-entrypoint-http-post.version>
-        <gravitee-entrypoint-http-get.version>2.0.0-alpha.1</gravitee-entrypoint-http-get.version>
-        <gravitee-reactor-message.version>5.0.0-alpha.2</gravitee-reactor-message.version>
+        <gravitee-entrypoint-http-post.version>2.0.0-alpha.2</gravitee-entrypoint-http-post.version>
+        <gravitee-entrypoint-http-get.version>2.0.0-alpha.2</gravitee-entrypoint-http-get.version>
+        <gravitee-reactor-message.version>5.0.0-alpha.11</gravitee-reactor-message.version>
         <groovy.version>3.0.19</groovy.version>
         <groovy-sandbox.version>1.27</groovy-sandbox.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -35,7 +35,7 @@ class io.gravitee.policy.groovy.utils.AttributesBasedExecutionContext
 class io.gravitee.policy.groovy.model.BindableExecutionContext
 class io.gravitee.policy.groovy.model.http.BindableHttpRequest
 class io.gravitee.policy.groovy.model.http.BindableHttpResponse
-class io.gravitee.policy.groovy.model.http.BindableHttpHeaders
+class io.gravitee.policy.groovy.model.BindableHttpHeaders
 class io.gravitee.policy.groovy.model.message.BindableMessage
 class io.gravitee.policy.groovy.model.message.BindableMessageAttributes
 class java.lang.Double
@@ -71,6 +71,7 @@ class java.util.Random
 class org.codehaus.groovy.runtime.DateGroovyMethods
 class org.apache.groovy.dateutil.extensions.DateUtilExtensions
 class org.apache.groovy.dateutil.extensions.DateUtilStaticExtensions
+class java.lang.Byte
 
 # Allows method signatures
 method groovy.json.JsonSlurper parseText java.lang.String
@@ -1177,6 +1178,7 @@ method org.codehaus.groovy.runtime.StringGroovyMethods tr java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpand java.lang.CharSequence int
 method org.codehaus.groovy.runtime.StringGroovyMethods unexpandLine java.lang.CharSequence int
+method java.lang.String format java.lang.String java.lang.Object[]
 
 # Allows constructor signatures
 

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
@@ -261,7 +261,7 @@ class GroovyPolicyTest {
     @Test
     void should_set_message_request_header() {
         var policy = new GroovyPolicy(buildConfig("set_message_header.groovy"));
-        var message = new DefaultMessage().headers(HttpHeaders.create());
+        var message = DefaultMessage.builder().headers(HttpHeaders.create()).build();
 
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
@@ -274,7 +274,7 @@ class GroovyPolicyTest {
     @Test
     void should_set_message_response_header() {
         var policy = new GroovyPolicy(buildConfig("set_message_header.groovy"));
-        var message = new DefaultMessage().headers(HttpHeaders.create());
+        var message = DefaultMessage.builder().headers(HttpHeaders.create()).build();
 
         when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageResponse(ctx).test().assertNoValues();
@@ -287,7 +287,7 @@ class GroovyPolicyTest {
     @Test
     void should_remove_message_request_header() {
         var policy = new GroovyPolicy(buildConfig("remove_message_header.groovy"));
-        var message = new DefaultMessage().headers(HttpHeaders.create().set("x-context", "test"));
+        var message = DefaultMessage.builder().headers(HttpHeaders.create().set("x-context", "test")).build();
 
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
@@ -300,7 +300,7 @@ class GroovyPolicyTest {
     @Test
     void should_remove_message_response_header() {
         var policy = new GroovyPolicy(buildConfig("remove_message_header.groovy"));
-        var message = new DefaultMessage().headers(HttpHeaders.create().set("x-context", "test"));
+        var message = DefaultMessage.builder().headers(HttpHeaders.create().set("x-context", "test")).build();
 
         when(response.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageResponse(ctx).test().assertNoValues();
@@ -313,7 +313,7 @@ class GroovyPolicyTest {
     @Test
     void should_set_message_attribute() {
         var policy = new GroovyPolicy(buildConfig("set_message_attribute.groovy"));
-        var message = new DefaultMessage();
+        var message = DefaultMessage.builder().build();
 
         when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
         policy.onMessageRequest(ctx).test().assertNoValues();
@@ -330,7 +330,7 @@ class GroovyPolicyTest {
     @Test
     void should_get_message_binary_content_as_base64() {
         var policy = new GroovyPolicy(buildConfig("get_message_binary_content.groovy"));
-        var message = new DefaultMessage();
+        var message = DefaultMessage.builder().build();
         byte[] isoEncodedCharacter = "é".getBytes(StandardCharsets.ISO_8859_1);
         message.content(Buffer.buffer(isoEncodedCharacter));
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-7782

**Description**

updating whitelist file to remove warning messages from log

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-APIM-7782-fix-warning-message-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/3.0.0-APIM-7782-fix-warning-message-SNAPSHOT/gravitee-policy-groovy-3.0.0-APIM-7782-fix-warning-message-SNAPSHOT.zip)
  <!-- Version placeholder end -->
