### PR TITLE
chore(renovate): use preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,3 @@
 {
-    "extends": ["config:base", "schedule:earlyMondays"],
-    "prConcurrentLimit": 3,
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "rangeStrategy": "replace"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:plugin"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,10 @@
     </parent>
 
     <properties>
-        <gravitee-apim.version>4.6.0-alpha.3</gravitee-apim.version>
+        <gravitee-apim.version>4.6.17</gravitee-apim.version>
         <gravitee-entrypoint-http-post.version>2.0.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-http-get.version>2.0.0</gravitee-entrypoint-http-get.version>
-        <gravitee-reactor-message.version>5.0.0</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>5.0.2</gravitee-reactor-message.version>
         <groovy.version>3.0.19</groovy.version>
         <groovy-sandbox.version>1.30</groovy-sandbox.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.7</version>
+        <version>22.5.1</version>
     </parent>
 
     <properties>
@@ -42,7 +42,6 @@
         <groovy-sandbox.version>1.30</groovy-sandbox.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <guava.version>30.1.1-jre</guava.version>
-        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -280,23 +279,27 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>LICENSE.txt</exclude>
-                        <exclude>Jenkinsfile</exclude>
-                        <exclude>**/README</exclude>
-                        <exclude>src/main/packaging/**</exclude>
-                        <exclude>src/test/resources/**</exclude>
-                        <exclude>src/main/resources/**</exclude>
-                        <exclude>src/main/webapp/**</exclude>
-                        <exclude>node_modules/**</exclude>
-                        <exclude>dist/**</exclude>
-                        <exclude>.tmp/**</exclude>
-                        <exclude>bower_components/**</exclude>
-                        <exclude>.*</exclude>
-                        <exclude>.*/**</exclude>
-                        <exclude>**/*.adoc</exclude>
-                        <exclude>**/org/kohsuke/groovy/sandbox/**</exclude>
-                    </excludes>
+                    <licenseSets>
+                        <licenseSet>
+                            <excludes>
+                                <exclude>LICENSE.txt</exclude>
+                                <exclude>Jenkinsfile</exclude>
+                                <exclude>**/README</exclude>
+                                <exclude>src/main/packaging/**</exclude>
+                                <exclude>src/test/resources/**</exclude>
+                                <exclude>src/main/resources/**</exclude>
+                                <exclude>src/main/webapp/**</exclude>
+                                <exclude>node_modules/**</exclude>
+                                <exclude>dist/**</exclude>
+                                <exclude>.tmp/**</exclude>
+                                <exclude>bower_components/**</exclude>
+                                <exclude>.*</exclude>
+                                <exclude>.*/**</exclude>
+                                <exclude>**/*.adoc</exclude>
+                                <exclude>**/org/kohsuke/groovy/sandbox/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
         <groovy-sandbox.version>1.30</groovy-sandbox.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <guava.version>30.1.1-jre</guava.version>
+
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
@@ -239,7 +242,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>


### PR DESCRIPTION
**Description**

Bump dependencies

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.3-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/3.0.3-bump-dependencies-SNAPSHOT/gravitee-policy-groovy-3.0.3-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
