### PR TITLE
fix: support Groovy subscript header assignment on HTTP and Kafka messages

### DIFF
--- a/src/main/java/io/gravitee/policy/groovy/model/BindableHttpHeaders.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/BindableHttpHeaders.java
@@ -17,17 +17,14 @@ package io.gravitee.policy.groovy.model;
 
 import io.gravitee.gateway.api.http.HttpHeaders;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class BindableHttpHeaders implements Map<String, List<String>> {
+public class BindableHttpHeaders extends BindableMessageHeaders {
 
     private final HttpHeaders headers;
 
@@ -51,20 +48,8 @@ public class BindableHttpHeaders implements Map<String, List<String>> {
     }
 
     @Override
-    public boolean containsValue(Object value) {
-        throw new IllegalStateException();
-    }
-
-    @Override
     public List<String> get(Object key) {
         return headers.getAll((String) key);
-    }
-
-    @SuppressWarnings("unused")
-    public List<String> put(String key, String value) {
-        List<String> oldValue = get(key);
-        headers.set(key, List.of(value));
-        return oldValue;
     }
 
     @Override
@@ -82,27 +67,19 @@ public class BindableHttpHeaders implements Map<String, List<String>> {
     }
 
     @Override
-    public void putAll(@Nonnull Map<? extends String, ? extends List<String>> all) {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
     public void clear() {
-        headers.clear();
+        try {
+            headers.clear();
+        } catch (UnsupportedOperationException unsupported) {
+            // Some backing header lists are unmodifiable and reject bulk clear; per-name remove works.
+            for (String name : new ArrayList<>(headers.names())) {
+                headers.remove(name);
+            }
+        }
     }
 
     @Override
     public Set<String> keySet() {
         return headers.names();
-    }
-
-    @Override
-    public Collection<List<String>> values() {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
-    }
-
-    @Override
-    public Set<Entry<String, List<String>>> entrySet() {
-        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
     }
 }

--- a/src/main/java/io/gravitee/policy/groovy/model/BindableMessageHeaders.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/BindableMessageHeaders.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.groovy.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * Declares {@code putAt}/{@code getAt} so Groovy subscript assignment resolves here before falling
+ * through to DGM's {@code putAt(Map, Object, Object)}, which would cast-fail on the
+ * {@code Map<String, List<String>>} bridge method for non-{@link List} values.
+ */
+public abstract class BindableMessageHeaders implements Map<String, List<String>> {
+
+    @Override
+    public boolean containsValue(Object value) {
+        throw new IllegalStateException();
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> put(String key, String value) {
+        return put(key, List.of(value));
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> putAt(String key, String value) {
+        return put(key, value);
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> putAt(String key, List<String> value) {
+        return put(key, value);
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> putAt(String key, Object value) {
+        if (value == null) {
+            return remove(key);
+        }
+        if (value instanceof List<?> list) {
+            List<String> stringList = new ArrayList<>(list.size());
+            for (Object element : list) {
+                stringList.add(element == null ? null : element.toString());
+            }
+            return put(key, stringList);
+        }
+        return put(key, value.toString());
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> getAt(String key) {
+        return get(key);
+    }
+
+    @Override
+    public void putAll(@Nonnull Map<? extends String, ? extends List<String>> all) {
+        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        throw new UnsupportedOperationException("Groovy scripts do not support accessing this method");
+    }
+}

--- a/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaMessage.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaMessage.java
@@ -33,6 +33,11 @@ public class BindableKafkaMessage extends BindableMessage {
         this.kafkaMessage = kafkaMessage;
     }
 
+    @Override
+    public BindableKafkaRecordHeaders getHeaders() {
+        return new BindableKafkaRecordHeaders(kafkaMessage);
+    }
+
     /**
      * Returns the message key as a string. Use {@link #getKeyAsBuffer()} for raw binary access.
      */

--- a/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaRecordHeaders.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaRecordHeaders.java
@@ -46,12 +46,13 @@ public class BindableKafkaRecordHeaders extends BindableMessageHeaders {
 
     @Override
     public boolean containsKey(Object key) {
-        return kafkaMessage.recordHeaders().containsKey((String) key);
+        return kafkaMessage.recordHeaders().containsKey(key);
     }
 
     @Override
+    @SuppressWarnings("java:S1168") // Map.get contract: null signals absence; put() relies on this to return the previous value or null.
     public List<String> get(Object key) {
-        Buffer value = kafkaMessage.recordHeaders().get((String) key);
+        Buffer value = kafkaMessage.recordHeaders().get(key);
         if (value == null) {
             return null;
         }

--- a/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaRecordHeaders.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/message/BindableKafkaRecordHeaders.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.groovy.model.message;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.message.kafka.KafkaMessage;
+import io.gravitee.policy.groovy.model.BindableMessageHeaders;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Replaces the parent's HTTP-backed wrapper because {@link KafkaMessage#headers()} throws.
+ * Record headers are single-valued {@link Buffer}s, so list-valued writes keep the last element.
+ */
+public class BindableKafkaRecordHeaders extends BindableMessageHeaders {
+
+    private final KafkaMessage kafkaMessage;
+
+    public BindableKafkaRecordHeaders(KafkaMessage kafkaMessage) {
+        this.kafkaMessage = kafkaMessage;
+    }
+
+    @Override
+    public int size() {
+        return kafkaMessage.recordHeaders().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return kafkaMessage.recordHeaders().isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return kafkaMessage.recordHeaders().containsKey((String) key);
+    }
+
+    @Override
+    public List<String> get(Object key) {
+        Buffer value = kafkaMessage.recordHeaders().get((String) key);
+        if (value == null) {
+            return null;
+        }
+        List<String> wrapped = new ArrayList<>(1);
+        wrapped.add(value.toString());
+        return wrapped;
+    }
+
+    @Override
+    public List<String> put(String key, List<String> value) {
+        List<String> oldValue = get(key);
+        if (value == null || value.isEmpty()) {
+            kafkaMessage.removeRecordHeader(key);
+            return oldValue;
+        }
+        String last = value.get(value.size() - 1);
+        if (last == null) {
+            kafkaMessage.removeRecordHeader(key);
+        } else {
+            kafkaMessage.putRecordHeader(key, Buffer.buffer(last));
+        }
+        return oldValue;
+    }
+
+    @Override
+    public List<String> remove(Object key) {
+        List<String> oldValue = get(key);
+        kafkaMessage.removeRecordHeader((String) key);
+        return oldValue;
+    }
+
+    @Override
+    public void clear() {
+        for (String name : new ArrayList<>(kafkaMessage.recordHeaders().keySet())) {
+            kafkaMessage.removeRecordHeader(name);
+        }
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return kafkaMessage.recordHeaders().keySet();
+    }
+}

--- a/src/main/java/io/gravitee/policy/groovy/model/message/BindableMessage.java
+++ b/src/main/java/io/gravitee/policy/groovy/model/message/BindableMessage.java
@@ -19,6 +19,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.policy.groovy.model.BindableHttpHeaders;
+import io.gravitee.policy.groovy.model.BindableMessageHeaders;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,7 @@ public class BindableMessage implements Message {
         return message.headers();
     }
 
-    public BindableHttpHeaders getHeaders() {
+    public BindableMessageHeaders getHeaders() {
         return new BindableHttpHeaders(headers());
     }
 

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -35,9 +35,11 @@ class io.gravitee.policy.groovy.utils.AttributesBasedExecutionContext
 class io.gravitee.policy.groovy.model.BindableExecutionContext
 class io.gravitee.policy.groovy.model.http.BindableHttpRequest
 class io.gravitee.policy.groovy.model.http.BindableHttpResponse
+class io.gravitee.policy.groovy.model.BindableMessageHeaders
 class io.gravitee.policy.groovy.model.BindableHttpHeaders
 class io.gravitee.policy.groovy.model.message.BindableMessage
 class io.gravitee.policy.groovy.model.message.BindableKafkaMessage
+class io.gravitee.policy.groovy.model.message.BindableKafkaRecordHeaders
 class io.gravitee.policy.groovy.model.message.BindableMessageAttributes
 class io.gravitee.gateway.api.buffer.Buffer
 class java.lang.Double

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyKafkaTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyKafkaTest.java
@@ -215,7 +215,7 @@ class GroovyPolicyKafkaTest {
             onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
             assertThat(message.recordHeaders()).containsKey("X-Internal-Status");
-            assertThat(message.recordHeaders().get("X-Internal-Status").toString()).isEqualTo("Processed");
+            assertThat(message.recordHeaders().get("X-Internal-Status")).hasToString("Processed");
         }
 
         @Test
@@ -231,7 +231,7 @@ class GroovyPolicyKafkaTest {
 
             // Kafka record headers are single-valued; the Groovy binding keeps the last element.
             assertThat(message.recordHeaders()).containsKey("X-Trace");
-            assertThat(message.recordHeaders().get("X-Trace").toString()).isEqualTo("second");
+            assertThat(message.recordHeaders().get("X-Trace")).hasToString("second");
         }
 
         @Test

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyKafkaTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyKafkaTest.java
@@ -30,7 +30,9 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -200,6 +202,69 @@ class GroovyPolicyKafkaTest {
 
             onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertError(Throwable.class);
         }
+
+        @Test
+        void should_set_kafka_record_header_with_subscript_string_assignment() {
+            var policy = new GroovyPolicy(buildConfig("set_kafka_message_header_subscript.groovy"));
+
+            when(kafkaMessageRequest.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+            policy.onMessageRequest(kafkaMessageExecutionContext).test().assertNoValues();
+
+            var message = mockKafkaMessage("topic", "key", Buffer.buffer("payload"));
+
+            onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+            assertThat(message.recordHeaders()).containsKey("X-Internal-Status");
+            assertThat(message.recordHeaders().get("X-Internal-Status").toString()).isEqualTo("Processed");
+        }
+
+        @Test
+        void should_set_kafka_record_header_with_subscript_list_assignment() {
+            var policy = new GroovyPolicy(buildConfig("set_kafka_message_header_subscript_list.groovy"));
+
+            when(kafkaMessageRequest.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+            policy.onMessageRequest(kafkaMessageExecutionContext).test().assertNoValues();
+
+            var message = mockKafkaMessage("topic", "key", Buffer.buffer("payload"));
+
+            onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+            // Kafka record headers are single-valued; the Groovy binding keeps the last element.
+            assertThat(message.recordHeaders()).containsKey("X-Trace");
+            assertThat(message.recordHeaders().get("X-Trace").toString()).isEqualTo("second");
+        }
+
+        @Test
+        void should_read_kafka_record_header_as_list() {
+            var policy = new GroovyPolicy(buildConfig("read_kafka_message_header.groovy"));
+
+            when(kafkaMessageRequest.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+            policy.onMessageRequest(kafkaMessageExecutionContext).test().assertNoValues();
+
+            var message = mockKafkaMessage("topic", "key", Buffer.buffer("payload"));
+            message.putRecordHeader("X-Incoming", Buffer.buffer("value-from-broker"));
+
+            onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+            assertThat(message.attributes()).containsEntry("echoedHeader", "value-from-broker");
+        }
+
+        @Test
+        void should_remove_kafka_record_header() {
+            var policy = new GroovyPolicy(buildConfig("remove_kafka_message_header.groovy"));
+
+            when(kafkaMessageRequest.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+            policy.onMessageRequest(kafkaMessageExecutionContext).test().assertNoValues();
+
+            var message = mockKafkaMessage("topic", "key", Buffer.buffer("payload"));
+            message.putRecordHeader("X-Remove-Me", Buffer.buffer("doomed"));
+            message.putRecordHeader("X-Keep", Buffer.buffer("kept"));
+
+            onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+            assertThat(message.recordHeaders()).doesNotContainKey("X-Remove-Me");
+            assertThat(message.recordHeaders()).containsKey("X-Keep");
+        }
     }
 
     @Nested
@@ -274,6 +339,7 @@ class GroovyPolicyKafkaTest {
     private static KafkaMessage mockKafkaMessage(String topic, String key, Buffer content) {
         var message = mock(KafkaMessage.class, withSettings().lenient());
         Map<String, Object> attributes = new HashMap<>();
+        Map<String, Buffer> recordHeaders = new LinkedHashMap<>();
 
         when(message.topic()).thenReturn(topic);
         when(message.key()).thenReturn(Buffer.buffer(key));
@@ -281,6 +347,15 @@ class GroovyPolicyKafkaTest {
         when(message.attributes()).thenReturn(attributes);
         when(message.attribute(any(String.class), any())).thenAnswer(invocation -> {
             attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+            return message;
+        });
+        when(message.recordHeaders()).thenAnswer(invocation -> Collections.unmodifiableMap(recordHeaders));
+        when(message.putRecordHeader(any(String.class), any(Buffer.class))).thenAnswer(invocation -> {
+            recordHeaders.put(invocation.getArgument(0), invocation.getArgument(1));
+            return message;
+        });
+        when(message.removeRecordHeader(any(String.class))).thenAnswer(invocation -> {
+            recordHeaders.remove((String) invocation.getArgument(0));
             return message;
         });
 

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
@@ -177,6 +177,24 @@ class GroovyPolicyTest {
     }
 
     @Test
+    void should_set_header_on_http_request_with_subscript_assignment() {
+        var policy = new GroovyPolicy(buildConfig("set_request_header_subscript.groovy"));
+
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        policy.onRequest(ctx).test().assertNoValues();
+
+        var headers = HttpHeaders.create();
+        when(request.headers()).thenReturn(headers);
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
+
+        assertThat(headers.get("x-context")).isEqualTo("test");
+    }
+
+    @Test
     void should_set_header_on_http_response() {
         var policy = new GroovyPolicy(buildConfig("set_response_header.groovy"));
 
@@ -282,6 +300,32 @@ class GroovyPolicyTest {
         onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
 
         assertThat(message.headers().get("x-context")).isEqualTo("test");
+    }
+
+    @Test
+    void should_set_message_request_header_with_subscript_string_assignment() {
+        var policy = new GroovyPolicy(buildConfig("set_message_header_subscript.groovy"));
+        var message = DefaultMessage.builder().headers(HttpHeaders.create()).build();
+
+        when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        policy.onMessageRequest(ctx).test().assertNoValues();
+
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+        assertThat(message.headers().get("x-context")).isEqualTo("test");
+    }
+
+    @Test
+    void should_set_message_request_header_with_subscript_list_assignment() {
+        var policy = new GroovyPolicy(buildConfig("set_message_header_subscript_list.groovy"));
+        var message = DefaultMessage.builder().headers(HttpHeaders.create()).build();
+
+        when(request.onMessage(onMessageCaptor.capture())).thenReturn(Completable.complete());
+        policy.onMessageRequest(ctx).test().assertNoValues();
+
+        onMessageCaptor.getValue().apply(message).test().awaitDone(10, TimeUnit.SECONDS).assertComplete().assertNoErrors();
+
+        assertThat(message.headers().getAll("x-context")).containsExactly("alpha", "beta");
     }
 
     @Test

--- a/src/test/resources/io/gravitee/policy/groovy/read_kafka_message_header.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/read_kafka_message_header.groovy
@@ -1,0 +1,2 @@
+def value = message.headers['X-Incoming']
+message.attribute('echoedHeader', value == null ? null : value[0])

--- a/src/test/resources/io/gravitee/policy/groovy/remove_kafka_message_header.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/remove_kafka_message_header.groovy
@@ -1,0 +1,1 @@
+message.headers.remove('X-Remove-Me')

--- a/src/test/resources/io/gravitee/policy/groovy/set_kafka_message_header_subscript.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/set_kafka_message_header_subscript.groovy
@@ -1,0 +1,1 @@
+message.headers['X-Internal-Status'] = 'Processed'

--- a/src/test/resources/io/gravitee/policy/groovy/set_kafka_message_header_subscript_list.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/set_kafka_message_header_subscript_list.groovy
@@ -1,0 +1,1 @@
+message.headers['X-Trace'] = ['first', 'second']

--- a/src/test/resources/io/gravitee/policy/groovy/set_message_header_subscript.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/set_message_header_subscript.groovy
@@ -1,0 +1,1 @@
+message.headers['x-context'] = 'test'

--- a/src/test/resources/io/gravitee/policy/groovy/set_message_header_subscript_list.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/set_message_header_subscript_list.groovy
@@ -1,0 +1,1 @@
+message.headers['x-context'] = ['alpha', 'beta']

--- a/src/test/resources/io/gravitee/policy/groovy/set_request_header_subscript.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/set_request_header_subscript.groovy
@@ -1,0 +1,1 @@
+request.headers['x-context'] = 'test'


### PR DESCRIPTION
## Summary

- `message.headers['X'] = 'value'` / `request.headers['X'] = 'value'` in Groovy scripts threw `ClassCastException: String cannot be cast to List` because Groovy's DGM `putAt(Map, Object, Object)` invoked `Map.put` through the `Map<String, List<String>>` bridge method and downcast the String value to a List.
- On Kafka messages the same expression blew up earlier (inside `BindableMessage.getHeaders()`) since `KafkaMessage.headers()` throws `IllegalStateException`. Reported against 4.11.X for V4 Native Kafka APIs.

## Changes

- New abstract `BindableMessageHeaders` hoists the Groovy binding surface (`putAt`/`getAt` overloads) so the Groovy MOP resolves them before the DGM fallback.
- `BindableHttpHeaders` now extends the base and keeps the multi-valued HTTP contract; `clear()` falls back to per-name removal when the backing list is unmodifiable.
- New `BindableKafkaRecordHeaders` delegates to `putRecordHeader` / `removeRecordHeader` / `recordHeaders`. Kafka headers are single-valued, so list-valued writes keep the last element (set-semantics).
- `BindableKafkaMessage.getHeaders()` covariantly returns the Kafka wrapper, bypassing the throwing `headers()` call.
- Whitelist updated with the two new classes.

## Test plan

- [x] HTTP request subscript `String` assignment — new test in `GroovyPolicyTest`
- [x] Message subscript `String` and `List<String>` assignment — new tests in `GroovyPolicyTest`
- [x] Kafka record header subscript `String` assignment (reproduces the exact script from the bug report) — new test in `GroovyPolicyKafkaTest`
- [x] Kafka record header subscript `List<String>` assignment (last-element-wins) — new test
- [x] Kafka record header read via subscript returns a single-element `List<String>` — new test
- [x] Kafka record header `.remove()` via Groovy — new test
- [x] Full suite: 61 passed, 0 failures (was 57)
- [x] Reproduction verified: removing only `BindableKafkaMessage.getHeaders()` override fails all 4 new Kafka tests with `IllegalStateException` from `KafkaMessage.headers()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.1-fix-groovy-subscript-headers-kafka-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/4.3.1-fix-groovy-subscript-headers-kafka-SNAPSHOT/gravitee-policy-groovy-4.3.1-fix-groovy-subscript-headers-kafka-SNAPSHOT.zip)
  <!-- Version placeholder end -->
