### PR TITLE
fix: hide overrideContent toggle for INTERACT phase in native Kafka

### DIFF
--- a/src/main/resources/schemas/schema-form-native-kafka.json
+++ b/src/main/resources/schemas/schema-form-native-kafka.json
@@ -70,7 +70,14 @@
         "overrideContent": {
             "title": "Override message content",
             "description": "Enable to replace the Kafka message content with the value returned by your script (applies to PUBLISH and SUBSCRIBE phases).",
-            "type": "boolean"
+            "type": "boolean",
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "context.flowPhase": ["PUBLISH", "SUBSCRIBE"]
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

A customer reported that toggling **"Override message content"** in the Groovy policy on the **INTERACT** phase of a native Kafka API had no effect — their `return '{"a": "b"}'` script ran but the message content was unchanged.

The toggle is honored only for PUBLISH/SUBSCRIBE phases (where `onMessageRequest/onMessageResponse(KafkaMessageExecutionContext)` calls `message.content(...)` when `overrideContent: true`). INTERACT runs `onRequest/onResponse(KafkaExecutionContext)` which has no message content to override, so the toggle silently does nothing.

This PR doesn't change runtime behavior — it just stops policy studio from rendering the toggle on INTERACT, so users aren't misled.

## Change

`schemas/schema-form-native-kafka.json` — restrict the `overrideContent` field to PUBLISH/SUBSCRIBE via `gioConfig.displayIf`, mirroring the pattern already used for `onRequestScript`/`onResponseScript`:

```json
"gioConfig": {
    "displayIf": {
        "$eq": {
            "context.flowPhase": ["PUBLISH", "SUBSCRIBE"]
        }
    }
}
```

## Test plan

- [x] Open policy studio, add a Groovy policy on a native Kafka API **INTERACT** phase → "Override message content" should NOT be visible
- [x] Switch the same step to **PUBLISH** → toggle visible
- [x] Switch to **SUBSCRIBE** → toggle visible
- [x] Existing API definitions that already persist `overrideContent: true` on an INTERACT step continue to load (the property is just hidden, not stripped)

## Notes

- No code change to `GroovyPolicy` — its INTERACT path already (correctly) ignores `overrideContent`.
- Worth a quick check that `["PUBLISH", "SUBSCRIBE"]` (multi-element array) is honored as "any-of" by gio policy-studio's `displayIf`. All other usages of `flowPhase` in this repo and neighboring policy repos use single-element arrays. If multi-element arrays are not yet supported, we'd need two separate fields or split into one displayIf per phase.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.2-fix-groovy-hide-override-content-interact-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/4.3.2-fix-groovy-hide-override-content-interact-SNAPSHOT/gravitee-policy-groovy-4.3.2-fix-groovy-hide-override-content-interact-SNAPSHOT.zip)
  <!-- Version placeholder end -->
