### PR TITLE
fix(docs): document native Kafka support in policy overview

### DIFF
--- a/.docgen/overview.md
+++ b/.docgen/overview.md
@@ -8,8 +8,9 @@ This policy is applicable to the following API types:
 * v4 LLM proxy APIs
 * v4 MCP proxy APIs
 * v4 A2A proxy APIs
+* v4 Native Kafka APIs
 
-**Note:** The Groovy policy is not supported by v4 TCP or Native APIs.
+**Note:** The Groovy policy is not supported by v4 TCP APIs.
 
 Several variables are automatically bound to the Groovy script. These let you read, and potentially modify, their values to define the behavior of the policy.
 
@@ -32,5 +33,15 @@ See the [Usage](#usage) section for object attributes and methods.
 | `request.content`  | When "Read content" is enabled   |
 | `response.content` | When "Read content" is enabled   |
 | `message.content`  | Always available                 |
+
+### Native Kafka APIs
+
+On v4 Native Kafka APIs the policy runs Groovy scripts across the Kafka flow phases:
+
+* **INTERACT** — runs on each Kafka request/response at the connection level (e.g. Produce, Fetch).
+* **PUBLISH** — runs on each individual Kafka message being produced.
+* **SUBSCRIBE** — runs on each individual Kafka message being consumed.
+
+The `context`, `result`, and (for `PUBLISH`/`SUBSCRIBE`) `message` variables are bound to the script. Note that `context.metrics` is not available in Kafka contexts, and `result.code`, `result.key`, and `result.contentType` are not forwarded to the client — Kafka uses its own protocol-level error codes.
 
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ This policy is applicable to the following API types:
 * v4 LLM proxy APIs
 * v4 MCP proxy APIs
 * v4 A2A proxy APIs
+* v4 Native Kafka APIs
 
-**Note:** The Groovy policy is not supported by v4 TCP or Native APIs.
+**Note:** The Groovy policy is not supported by v4 TCP APIs.
 
 Several variables are automatically bound to the Groovy script. These let you read, and potentially modify, their values to define the behavior of the policy.
 
@@ -42,6 +43,16 @@ See the [Usage](#usage) section for object attributes and methods.
 | `request.content`  | When "Read content" is enabled   |
 | `response.content` | When "Read content" is enabled   |
 | `message.content`  | Always available                 |
+
+### Native Kafka APIs
+
+On v4 Native Kafka APIs the policy runs Groovy scripts across the Kafka flow phases:
+
+* **INTERACT** — runs on each Kafka request/response at the connection level (e.g. Produce, Fetch).
+* **PUBLISH** — runs on each individual Kafka message being produced.
+* **SUBSCRIBE** — runs on each individual Kafka message being consumed.
+
+The `context`, `result`, and (for `PUBLISH`/`SUBSCRIBE`) `message` variables are bound to the script. Note that `context.metrics` is not available in Kafka contexts, and `result.code`, `result.key`, and `result.contentType` are not forwarded to the client — Kafka uses its own protocol-level error codes.
 
 
 

--- a/docs/POLICY_STUDIO_DOC.md
+++ b/docs/POLICY_STUDIO_DOC.md
@@ -9,8 +9,9 @@ This policy is applicable to the following API types:
 * v4 LLM proxy APIs
 * v4 MCP proxy APIs
 * v4 A2A proxy APIs
+* v4 Native Kafka APIs
 
-**Note:** The Groovy policy is not supported by v4 TCP or Native APIs.
+**Note:** The Groovy policy is not supported by v4 TCP APIs.
 
 Several variables are automatically bound to the Groovy script. These let you read, and potentially modify, their values to define the behavior of the policy.
 
@@ -33,6 +34,16 @@ See the [Usage](#usage) section for object attributes and methods.
 | `request.content`  | When "Read content" is enabled   |
 | `response.content` | When "Read content" is enabled   |
 | `message.content`  | Always available                 |
+
+### Native Kafka APIs
+
+On v4 Native Kafka APIs the policy runs Groovy scripts across the Kafka flow phases:
+
+* **INTERACT** — runs on each Kafka request/response at the connection level (e.g. Produce, Fetch).
+* **PUBLISH** — runs on each individual Kafka message being produced.
+* **SUBSCRIBE** — runs on each individual Kafka message being consumed.
+
+The `context`, `result`, and (for `PUBLISH`/`SUBSCRIBE`) `message` variables are bound to the script. Note that `context.metrics` is not available in Kafka contexts, and `result.code`, `result.key`, and `result.contentType` are not forwarded to the client — Kafka uses its own protocol-level error codes.
 
 
 


### PR DESCRIPTION
## What

Document native Kafka support in the policy's doc-gen overview, and regenerate the published docs.

The Groovy policy has supported **v4 Native Kafka APIs** since `4.3.0` (#121, `GroovyPolicy implements KafkaPolicy`), but `.docgen/overview.md` was never updated when that feature landed. It still listed Native APIs as **unsupported** and made no mention of Kafka — directly contradicting the code and the existing `docs/KAFKA_POLICY_STUDIO_DOC.md`.

## Changes

- `.docgen/overview.md` (source):
  - Add `v4 Native Kafka APIs` to the list of applicable API types.
  - Correct the unsupported note from "v4 TCP or Native APIs" to "v4 TCP APIs".
  - Add a **Native Kafka APIs** section describing the `INTERACT` / `PUBLISH` / `SUBSCRIBE` phases and the bound `context` / `result` / `message` variables, including the `context.metrics` and `result.code/key/contentType` caveats.
- `README.md` and `docs/POLICY_STUDIO_DOC.md`: regenerated from the doc-gen pipeline (`graviteeio/doc-gen`) — no manual edits.

## Notes

- Docs-only change; no code or behavior impact.
- Generated files were produced by running the doc-gen pipeline against `gravitee-doc-gen-config`, not hand-edited.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.4-docs-groovy-native-kafka-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/4.3.4-docs-groovy-native-kafka-support-SNAPSHOT/gravitee-policy-groovy-4.3.4-docs-groovy-native-kafka-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
