### PR TITLE
Fix Groovy 4 compatibility regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@5.5.0
-
+    gravitee: gravitee-io/gravitee@5
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:

--- a/.docgen/matrix.yaml
+++ b/.docgen/matrix.yaml
@@ -1,10 +1,17 @@
 rows:
     - data:
+          plugin: "5.x"
+          apim: "-"
+          am: "4.12.x and above"
+    - data:
           plugin: "4.x"
           apim: "4.9.x and above"
+          am: "-"
     - data:
           plugin: "3.x"
           apim: "4.6.x to 4.8.x"
+          am: "-"
     - data:
           plugin: "2.x"
           apim: "4.5.x and below"
+          am: "4.0.x to 4.11.x"

--- a/README.md
+++ b/README.md
@@ -290,11 +290,12 @@ The `groovy` policy can be applied to the following API types and flow phases.
 ## Compatibility matrix
 Strikethrough text indicates that a version is deprecated.
 
-| Plugin version| APIM |
-| --- | ---  |
-|4.x|4.9.x and above |
-|3.x|4.6.x to 4.8.x |
-|2.x|4.5.x and below |
+| Plugin version| APIM| AM |
+| --- | --- | ---  |
+|5.x|-|4.12.x and above |
+|4.x|4.9.x and above|- |
+|3.x|4.6.x to 4.8.x|- |
+|2.x|4.5.x and below|4.0.x to 4.11.x |
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-reactor-message.version>8.2.0</gravitee-reactor-message.version>
-        <groovy.version>3.0.19</groovy.version>
+        <groovy.version>4.0.30</groovy.version>
         <groovy-sandbox.version>1.30</groovy-sandbox.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <guava.version>30.1.1-jre</guava.version>
@@ -102,25 +102,25 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
             <version>${groovy.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-json</artifactId>
             <version>${groovy.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-xml</artifactId>
             <version>${groovy.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-dateutil</artifactId>
             <version>${groovy.version}</version>
         </dependency>

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
@@ -61,7 +61,7 @@ public class SecuredGroovyShell {
     private static final int CODE_CACHE_EXPIRATION_HOURS = 1;
 
     static {
-        // Do not change this block of code which is required to work with groovy 2.5 and the classloader used
+        // Do not change this block of code which is required to work with the classloader used
         // to load services
         ClassLoader loader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(GroovyPolicy.class.getClassLoader());

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredInterceptor.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredInterceptor.java
@@ -15,14 +15,16 @@
  */
 package io.gravitee.policy.groovy.sandbox;
 
+import groovy.lang.GroovyRuntimeException;
+import groovy.lang.MetaClass;
 import groovy.lang.Script;
 import io.gravitee.common.util.MultiValueMap;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 import org.kohsuke.groovy.sandbox.GroovyInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -70,7 +72,17 @@ public class SecuredInterceptor extends GroovyInterceptor {
     @Override
     public Object onSuperCall(Invoker invoker, Class senderType, Object receiver, String method, Object... args) throws Throwable {
         if (SecuredResolver.getInstance().isMethodAllowed(receiver, method, args)) {
-            return super.onSuperCall(invoker, senderType, receiver, method, args);
+            // groovy-sandbox's default super-call dispatch resolves the method against
+            // senderType.getSuperclass(). Since Groovy 4 the meta method index for super calls became
+            // strict (methodsForSuper(sender) only holds sender's super methods), so passing the
+            // superclass fails to resolve inherited methods (MissingMethodException). Invoke the super
+            // method ourselves using senderType so resolution starts at the proper superclass.
+            try {
+                MetaClass metaClass = InvokerHelper.getMetaClass(receiver.getClass());
+                return metaClass.invokeMethod(senderType, receiver, method, args, true, true);
+            } catch (GroovyRuntimeException gre) {
+                throw ScriptBytecodeAdapter.unwrap(gre);
+            }
         }
 
         throw new SecurityException("Failed to resolve method [ " + prettyPrint(receiver, method, args) + " ]");

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
@@ -526,7 +526,7 @@ public class SecuredResolver {
             Class<?> clazz = ClassUtils.forName(clazzName, SecuredResolver.class.getClassLoader());
             return Arrays.asList(memberAccessor.apply(clazz));
         } catch (NoClassDefFoundError e) {
-            log.warn("Unable to load members from class [{}], a transitive dependency is missing: {}", clazzName, e.getMessage());
+            log.error("Unable to load members from class [{}], a transitive dependency is missing: {}", clazzName, e.getMessage());
             return emptyList();
         }
     }

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredResolver.java
@@ -520,12 +520,20 @@ public class SecuredResolver {
         return clazz.getDeclaredMethod(methodName, argumentClasses);
     }
 
+    private static <T> List<T> safeGetDeclaredMembers(String clazzName, java.util.function.Function<Class<?>, T[]> memberAccessor)
+        throws ClassNotFoundException {
+        try {
+            Class<?> clazz = ClassUtils.forName(clazzName, SecuredResolver.class.getClassLoader());
+            return Arrays.asList(memberAccessor.apply(clazz));
+        } catch (NoClassDefFoundError e) {
+            log.warn("Unable to load members from class [{}], a transitive dependency is missing: {}", clazzName, e.getMessage());
+            return emptyList();
+        }
+    }
+
     private static List<Method> parseAllMethods(String declaration) throws ClassNotFoundException {
         String[] split = declaration.split(" ");
-        String clazzName = split[1];
-        Class<?> clazz = ClassUtils.forName(clazzName, SecuredResolver.class.getClassLoader());
-
-        return Arrays.asList(clazz.getDeclaredMethods());
+        return safeGetDeclaredMembers(split[1], Class::getDeclaredMethods);
     }
 
     private static Field parseField(String declaration) throws ClassNotFoundException, NoSuchFieldException {
@@ -539,10 +547,7 @@ public class SecuredResolver {
 
     private static List<Field> parseAllFields(String declaration) throws ClassNotFoundException {
         String[] split = declaration.split(" ");
-        String clazzName = split[1];
-        Class<?> clazz = ClassUtils.forName(clazzName, SecuredResolver.class.getClassLoader());
-
-        return Arrays.asList(clazz.getDeclaredFields());
+        return safeGetDeclaredMembers(split[1], Class::getDeclaredFields);
     }
 
     private static Constructor<?> parseConstructor(String declaration) throws ClassNotFoundException, NoSuchMethodException {
@@ -571,10 +576,7 @@ public class SecuredResolver {
 
     private static List<Constructor<?>> parseAllConstructors(String declaration) throws ClassNotFoundException {
         String[] split = declaration.split(" ");
-        String clazzName = split[1];
-        Class<?> clazz = ClassUtils.forName(clazzName, SecuredResolver.class.getClassLoader());
-
-        return Arrays.asList(clazz.getDeclaredConstructors());
+        return safeGetDeclaredMembers(split[1], Class::getDeclaredConstructors);
     }
 
     private static Class<?> parseAnnotation(String declaration) throws ClassNotFoundException {

--- a/src/main/resources/groovy-whitelist
+++ b/src/main/resources/groovy-whitelist
@@ -2,9 +2,9 @@
 class groovy.json.JsonOutput
 class groovy.json.JsonParserType
 class groovy.json.JsonSlurper
-class groovy.util.slurpersupport.Node
-class groovy.util.slurpersupport.NodeChild
-class groovy.util.XmlSlurper
+class groovy.xml.slurpersupport.Node
+class groovy.xml.slurpersupport.NodeChild
+class groovy.xml.XmlSlurper
 class io.gravitee.am.model.safe.ClientProperties
 class io.gravitee.am.model.safe.DomainProperties
 class io.gravitee.am.model.safe.UserProperties

--- a/src/test/resources/io/gravitee/policy/v3/groovy/read_xml.groovy
+++ b/src/test/resources/io/gravitee/policy/v3/groovy/read_xml.groovy
@@ -1,5 +1,5 @@
 
-import groovy.util.XmlSlurper
+import groovy.xml.XmlSlurper
 import groovy.json.JsonOutput
 
 def xmlSlurper = new XmlSlurper()


### PR DESCRIPTION
Two regressions surfaced after the Groovy 4 upgrade.

## Super method calls
`SecuredInterceptor.onSuperCall` delegated to groovy-sandbox's default dispatch, which resolves super calls against `senderType.getSuperclass()`. Since Groovy 4 the meta method index for super calls became strict (`methodsForSuper(sender)` only holds `sender`'s super methods), so this stepped one level too high and threw `MissingMethodException` on inherited methods. Any user script calling `super.someMethod()` broke at runtime.

We now perform the super invocation ourselves, passing `senderType` directly so resolution starts at the correct superclass. The sandbox security check is unchanged — disallowed super calls still raise `SecurityException`.

## XmlSlurper import
`XmlSlurper` moved from `groovy.util` to `groovy.xml` in Groovy 4. Updated the `read_xml` test resource accordingly (the runtime whitelist was already correct).

## Testing
Full suite green (163 tests).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.0-fix-tests-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/5.0.0-fix-tests-SNAPSHOT/gravitee-policy-groovy-5.0.0-fix-tests-SNAPSHOT.zip)
  <!-- Version placeholder end -->
