### PR TITLE
fix: declare default schema explicitly in plugin manifest

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -7,6 +7,7 @@ type=policy
 category=others
 documentation=POLICY_STUDIO_DOC.md
 icon=groovy.svg
+schema=schema-form.json
 proxy=REQUEST,RESPONSE
 message=REQUEST,RESPONSE,MESSAGE_REQUEST,MESSAGE_RESPONSE
 mcp_proxy=REQUEST,RESPONSE


### PR DESCRIPTION


**Issue**
https://gravitee.atlassian.net/browse/APIM-14644

**Description**

The plugin manifest only declared `native_kafka.schema`, leaving the default `schema` property unset. In that case `gravitee-plugin-core` (`AbstractConfigurablePluginManager#getSchema`) falls back to `getFirstFile()`, which returns `dir.listFiles()[0]` with **no ordering guarantee**. With two files in `schemas/` (`schema-form.json` and `schema-form-native-kafka.json`), APIM could serve the native-kafka schema for proxy/message APIs, hiding fields such as `readContent` / `overrideContent` from the policy studio form.

Declaring `schema=schema-form.json` in `plugin.properties` makes the default schema resolution deterministic.

**Additional context**

Reproduction: open the Groovy policy configuration on a proxy/message API in the console — the generic form was rendered from `schema-form-native-kafka.json` instead of `schema-form.json`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.2-fix-default-schema-resolution-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/5.0.2-fix-default-schema-resolution-SNAPSHOT/gravitee-policy-groovy-5.0.2-fix-default-schema-resolution-SNAPSHOT.zip)
  <!-- Version placeholder end -->
