### PR TITLE
fix(groovy): reintroduce script execution timeout with interface-safe default

### DIFF
--- a/.docgen/gateway-config/after.md
+++ b/.docgen/gateway-config/after.md
@@ -2,3 +2,16 @@
 **Security implications**
 
 Exercise care when using classes or methods. In some cases, giving access to all methods of a class may make unwanted methods accessible via transitivity and risk security breaches.
+### Script execution timeout
+
+Groovy scripts are interrupted if they run longer than the configured timeout, to protect the gateway from long-running or never-ending scripts. By default, the timeout instrumentation skips interfaces so that scripts declaring Groovy interfaces (or annotations) keep compiling; the `strictExecutionTimeout` option of the policy rejects such scripts instead, guaranteeing that no part of the script can escape the timeout.
+
+| System property | Default | Description |
+| --- | --- | --- |
+| `gravitee.policy.groovy.script.timeout.seconds` | `5` | Maximum script execution time in seconds, clamped between `1` and `30`. |
+
+Example:
+
+```
+-Dgravitee.policy.groovy.script.timeout.seconds=10
+```

--- a/README.md
+++ b/README.md
@@ -342,6 +342,20 @@ gateway:
 **Security implications**
 
 Exercise care when using classes or methods. In some cases, giving access to all methods of a class may make unwanted methods accessible via transitivity and risk security breaches.
+### Script execution timeout
+
+Groovy scripts are interrupted if they run longer than the configured timeout, to protect the gateway from long-running or never-ending scripts. By default, the timeout instrumentation skips interfaces so that scripts declaring Groovy interfaces (or annotations) keep compiling; the `strictExecutionTimeout` option of the policy rejects such scripts instead, guaranteeing that no part of the script can escape the timeout.
+
+| System property | Default | Description |
+| --- | --- | --- |
+| `gravitee.policy.groovy.script.timeout.seconds` | `5` | Maximum script execution time in seconds, clamped between `1` and `30`. |
+
+Example:
+
+```
+-Dgravitee.policy.groovy.script.timeout.seconds=10
+```
+
 
 
 ### Configuration options
@@ -353,6 +367,7 @@ Exercise care when using classes or methods. In some cases, giving access to all
 | Override content<br>`overrideContent`| boolean|  | | Enable to override the content of the request or response with the value returned by your script.|
 | Read content<br>`readContent`| boolean|  | | Enable if your script needs to access the content of the HTTP request or response in your script.|
 | Script<br>`script`| string|  | | Groovy script to evaluate.|
+| Strict execution timeout<br>`strictExecutionTimeout`| boolean|  | | Rejects scripts that cannot be fully covered by the execution timeout protection, such as scripts declaring Groovy interfaces or annotations. Enabling this option improves security by guaranteeing that no part of the script can escape the execution timeout. Recommended if your script does not declare interfaces.|
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/gravitee/policy/groovy/GroovyPolicy.java
+++ b/src/main/java/io/gravitee/policy/groovy/GroovyPolicy.java
@@ -62,7 +62,7 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
 
         // Precompile all the scripts on a io schedulers to get ready when necessary.
         scriptFlowable
-            .doOnNext(GROOVY_SHELL::compile)
+            .doOnNext(script -> groovyShell().compile(script))
             .subscribeOn(Schedulers.io())
             .doOnError(e -> log.warn("Error while compiling script. Ignoring", e))
             .onErrorComplete()
@@ -152,7 +152,8 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
     }
 
     private Maybe<Buffer> runContentAwareScript(HttpExecutionContext ctx, Binding binding, String script) {
-        return GROOVY_SHELL.evaluateRx(script, binding)
+        return groovyShell()
+            .evaluateRx(script, binding)
             .onErrorResumeNext(e -> {
                 log.error(SCRIPT_EXECUTION_ERROR_MESSAGE, e);
                 return ctx.interruptBodyWith(
@@ -179,7 +180,8 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
     }
 
     private Completable runScript(HttpExecutionContext ctx, Binding binding, String script) {
-        return GROOVY_SHELL.evaluateRx(script, binding)
+        return groovyShell()
+            .evaluateRx(script, binding)
             .ignoreElement()
             .onErrorResumeNext(e -> {
                 log.error(SCRIPT_EXECUTION_ERROR_MESSAGE, e);
@@ -226,7 +228,8 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
         var script = configuration.getScript();
         var binding = GroovyBindings.bindMessage(ctx, message);
 
-        return GROOVY_SHELL.evaluateRx(script, binding)
+        return groovyShell()
+            .evaluateRx(script, binding)
             .onErrorResumeNext(e ->
                 ctx.interruptMessageWith(
                     new ExecutionFailure(INTERNAL_SERVER_ERROR_500)
@@ -294,7 +297,8 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
     }
 
     private Completable runKafkaScript(KafkaExecutionContext ctx, Binding binding, String script) {
-        return GROOVY_SHELL.evaluateRx(script, binding)
+        return groovyShell()
+            .evaluateRx(script, binding)
             .ignoreElement()
             .onErrorResumeNext(e -> {
                 log.error(SCRIPT_EXECUTION_ERROR_MESSAGE, e);
@@ -315,7 +319,8 @@ public class GroovyPolicy extends GroovyPolicyV3 implements Policy, KafkaPolicy 
         var script = configuration.getScript();
         var binding = GroovyBindings.bindKafkaMessage(ctx, message);
 
-        return GROOVY_SHELL.evaluateRx(script, binding)
+        return groovyShell()
+            .evaluateRx(script, binding)
             .onErrorResumeNext(e -> {
                 log.error("An error occurred while executing Groovy script on Kafka message", e);
                 return ctx.executionContext().interruptWith(Errors.UNKNOWN_SERVER_ERROR).toMaybe();

--- a/src/main/java/io/gravitee/policy/groovy/configuration/GroovyPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/groovy/configuration/GroovyPolicyConfiguration.java
@@ -38,6 +38,13 @@ public class GroovyPolicyConfiguration implements PolicyConfiguration {
 
     private boolean overrideContent;
 
+    /**
+     * When {@code true}, scripts that cannot be fully covered by the execution timeout instrumentation
+     * (declaring interfaces or annotations) are rejected at compilation, guaranteeing that no part of the
+     * script can escape the timeout.
+     */
+    private boolean strictExecutionTimeout;
+
     private String script;
 
     private String onRequestScript;

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/InterfaceSafeTimedInterruptCustomizer.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/InterfaceSafeTimedInterruptCustomizer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.groovy.sandbox;
+
+import groovy.transform.TimedInterrupt;
+import java.util.HashMap;
+import java.util.Map;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.classgen.GeneratorContext;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
+import org.codehaus.groovy.control.customizers.CompilationCustomizer;
+
+/**
+ * Applies the {@link TimedInterrupt} transformation class by class, skipping interfaces.
+ *
+ * <p>The {@link TimedInterrupt} transformation injects instance fields into every class to track the script
+ * expiration time. Instance fields are illegal on interfaces, so any script declaring an interface (or an
+ * annotation) fails to compile when the transformation is applied module-wide. Interfaces hold no executable
+ * code to instrument, so skipping them does not weaken the execution timeout.</p>
+ *
+ * @author GraviteeSource Team
+ */
+public class InterfaceSafeTimedInterruptCustomizer extends CompilationCustomizer {
+
+    private final ASTTransformationCustomizer delegate;
+
+    public InterfaceSafeTimedInterruptCustomizer(Map<String, Object> annotationParameters) {
+        this(new ASTTransformationCustomizer(perClassParameters(annotationParameters), TimedInterrupt.class));
+    }
+
+    private InterfaceSafeTimedInterruptCustomizer(ASTTransformationCustomizer delegate) {
+        super(delegate.getPhase());
+        this.delegate = delegate;
+    }
+
+    /**
+     * Each class node is annotated individually; applying the transformation to all classes of the module
+     * would reach the interfaces this customizer intends to skip.
+     */
+    private static Map<String, Object> perClassParameters(Map<String, Object> annotationParameters) {
+        Map<String, Object> parameters = new HashMap<>(annotationParameters);
+        parameters.put("applyToAllClasses", false);
+        return parameters;
+    }
+
+    @Override
+    public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
+        if (!classNode.isInterface()) {
+            delegate.call(source, context, classNode);
+        }
+    }
+}

--- a/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
+++ b/src/main/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShell.java
@@ -21,15 +21,21 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyCodeSource;
 import groovy.lang.GroovyShell;
 import groovy.lang.Script;
+import groovy.transform.TimedInterrupt;
 import io.gravitee.policy.groovy.GroovyPolicy;
 import io.gravitee.policy.groovy.utils.Sha1;
-import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.groovy.json.internal.FastStringUtils;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
+import org.codehaus.groovy.ast.tools.GeneralUtils;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
 import org.codehaus.groovy.control.customizers.SecureASTCustomizer;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.kohsuke.groovy.sandbox.GroovyInterceptor;
@@ -39,7 +45,15 @@ import org.kohsuke.groovy.sandbox.SandboxTransformer;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class SecuredGroovyShell {
+
+    /** Maximum script execution time in seconds; clamped to [{@value #SCRIPT_TIMEOUT_MIN_SECONDS}, {@value #SCRIPT_TIMEOUT_MAX_SECONDS}]. */
+    static final String SCRIPT_TIMEOUT_PROPERTY = "gravitee.policy.groovy.script.timeout.seconds";
+
+    static final long SCRIPT_TIMEOUT_DEFAULT_SECONDS = 5L;
+    static final long SCRIPT_TIMEOUT_MIN_SECONDS = 1L;
+    static final long SCRIPT_TIMEOUT_MAX_SECONDS = 30L;
 
     /**
      * Number of hours to keep compiled script in cache after the last time it was accessed.
@@ -60,6 +74,17 @@ public class SecuredGroovyShell {
     private final GroovyInterceptor groovyInterceptor;
 
     public SecuredGroovyShell() {
+        this(false);
+    }
+
+    /**
+     * @param strictTimeoutInstrumentation when {@code true}, the execution timeout instrumentation is applied
+     * to the whole script: scripts that cannot be fully instrumented (declaring interfaces or annotations)
+     * are rejected at compilation, which guarantees that no part of the script can escape the timeout. When
+     * {@code false}, the instrumentation skips interfaces so that such scripts keep compiling.
+     */
+
+    public SecuredGroovyShell(boolean strictTimeoutInstrumentation) {
         this.sources = CacheBuilder.newBuilder().expireAfterAccess(Duration.ofHours(CODE_CACHE_EXPIRATION_HOURS)).build();
 
         CompilerConfiguration conf = new CompilerConfiguration();
@@ -75,15 +100,31 @@ public class SecuredGroovyShell {
         secureASTCustomizer.setPackageAllowed(false);
         conf.addCompilationCustomizers(secureASTCustomizer);
 
-        // TODO: Use time interrupt to avoid long running scripts.
-        // Note: groovy scripts are currently run on vertx threads. Should be executed outside vertx to prevent possible server crash.
-        // ASTTransformationCustomizer timeInterrupt = new ASTTransformationCustomizer(Maps.of("value", 1L, "unit", propX(classX(TimeUnit.class), "SECONDS")), TimedInterrupt.class);
-        // conf.addCompilationCustomizers(timeInterrupt);
+        long scriptTimeoutSeconds = resolveScriptTimeoutSeconds();
+        log.debug("Groovy script execution timeout set to {} second(s) (property: {})", scriptTimeoutSeconds, SCRIPT_TIMEOUT_PROPERTY);
+
+        Map<String, Object> timedInterruptParams = Map.of(
+            "value",
+            scriptTimeoutSeconds,
+            "unit",
+            new PropertyExpression(GeneralUtils.classX(TimeUnit.class), "SECONDS")
+        );
+
+        if (strictTimeoutInstrumentation) {
+            conf.addCompilationCustomizers(new ASTTransformationCustomizer(timedInterruptParams, TimedInterrupt.class));
+        } else {
+            conf.addCompilationCustomizers(new InterfaceSafeTimedInterruptCustomizer(timedInterruptParams));
+        }
 
         this.groovyShell = new GroovyShell(conf);
 
         // Create a groovy interceptor to intercept all calls and check if they are allowed or not.
         this.groovyInterceptor = new SecuredInterceptor();
+    }
+
+    static long resolveScriptTimeoutSeconds() {
+        long value = Long.getLong(SCRIPT_TIMEOUT_PROPERTY, SCRIPT_TIMEOUT_DEFAULT_SECONDS);
+        return Math.max(SCRIPT_TIMEOUT_MIN_SECONDS, Math.min(SCRIPT_TIMEOUT_MAX_SECONDS, value));
     }
 
     /**
@@ -103,14 +144,9 @@ public class SecuredGroovyShell {
 
     public <T> Maybe<T> evaluateRx(String script, Binding binding) {
         final String key = getKey(script);
-        final boolean compiled = sources.getIfPresent(key) != null;
-        final Maybe<@NonNull T> groovyEval = Maybe.fromCallable(() -> evaluate(key, script, binding));
-
-        if (!compiled) {
-            return groovyEval.subscribeOn(Schedulers.io()).observeOn(Schedulers.computation());
-        }
-
-        return groovyEval;
+        return Maybe.<T>fromCallable(() -> evaluate(key, script, binding))
+            .subscribeOn(Schedulers.io())
+            .observeOn(Schedulers.computation());
     }
 
     private <T> T evaluate(String key, String script, Binding binding) {

--- a/src/main/java/io/gravitee/policy/v3/groovy/GroovyPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/groovy/GroovyPolicyV3.java
@@ -50,10 +50,24 @@ public class GroovyPolicyV3 {
 
     protected final GroovyPolicyConfiguration configuration;
 
-    protected static final SecuredGroovyShell GROOVY_SHELL = new SecuredGroovyShell();
+    protected static final SecuredGroovyShell GROOVY_SHELL = new SecuredGroovyShell(false);
+
+    /**
+     * Lazily created so gateways with no policy opting into the strict execution timeout don't pay for a
+     * second shell. Each shell keeps its own compiled-script cache, as the same script compiles differently
+     * in each mode.
+     */
+    private static class StrictGroovyShellHolder {
+
+        private static final SecuredGroovyShell INSTANCE = new SecuredGroovyShell(true);
+    }
 
     public GroovyPolicyV3(GroovyPolicyConfiguration configuration) {
         this.configuration = configuration;
+    }
+
+    protected SecuredGroovyShell groovyShell() {
+        return configuration.isStrictExecutionTimeout() ? StrictGroovyShellHolder.INSTANCE : GROOVY_SHELL;
     }
 
     @OnRequest
@@ -190,7 +204,7 @@ public class GroovyPolicyV3 {
                 binding.setVariable(RESULT_VARIABLE_NAME, new PolicyResult());
 
                 // And run script
-                GROOVY_SHELL.evaluate(script, binding);
+                groovyShell().evaluate(script, binding);
 
                 PolicyResult result = (PolicyResult) binding.getVariable(RESULT_VARIABLE_NAME);
 
@@ -229,7 +243,7 @@ public class GroovyPolicyV3 {
         binding.setVariable(RESULT_VARIABLE_NAME, new PolicyResult());
 
         // And run script
-        String content = GROOVY_SHELL.evaluate(script, binding);
+        String content = groovyShell().evaluate(script, binding);
 
         PolicyResult result = (PolicyResult) binding.getVariable(RESULT_VARIABLE_NAME);
         if (result.getState() == PolicyResult.State.FAILURE) {

--- a/src/main/resources/schemas/schema-form-native-kafka.json
+++ b/src/main/resources/schemas/schema-form-native-kafka.json
@@ -78,6 +78,12 @@
                     }
                 }
             }
+        },
+        "strictExecutionTimeout": {
+            "title": "Strict execution timeout",
+            "description": "Rejects scripts that cannot be fully covered by the execution timeout protection, such as scripts declaring Groovy interfaces or annotations. Enabling this option improves security by guaranteeing that no part of the script can escape the execution timeout. Recommended if your script does not declare interfaces.",
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -37,6 +37,12 @@
                 "hidden": true
             }
         },
+        "strictExecutionTimeout": {
+            "title": "Strict execution timeout",
+            "description": "Rejects scripts that cannot be fully covered by the execution timeout protection, such as scripts declaring Groovy interfaces or annotations. Enabling this option improves security by guaranteeing that no part of the script can escape the execution timeout. Recommended if your script does not declare interfaces.",
+            "type": "boolean",
+            "default": false
+        },
         "onRequestScript": {
             "title": "On-request script",
             "description": "Groovy script to evaluate during the OnRequest phase.",

--- a/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/GroovyPolicyTest.java
@@ -367,6 +367,49 @@ class GroovyPolicyTest {
         assertThat(message.attributes()).containsEntry("count", 100);
     }
 
+    @Test
+    void should_run_script_declaring_interface_by_default() {
+        var policy = new GroovyPolicy(buildConfig("declare_interface.groovy"));
+
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        policy.onRequest(ctx).test().assertNoValues();
+
+        var headers = HttpHeaders.create().set("x-context", "test");
+        when(request.headers()).thenReturn(headers);
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors();
+
+        assertThat(headers.size()).isZero();
+    }
+
+    @Test
+    void should_fail_to_run_script_declaring_interface_when_strict_execution_timeout_is_enabled() {
+        var config = GroovyPolicyConfiguration.builder()
+            .script(loadScript("declare_interface.groovy"))
+            .readContent(true)
+            .strictExecutionTimeout(true)
+            .build();
+        var policy = new GroovyPolicy(config);
+
+        when(request.onBody(onBodyCaptor.capture())).thenReturn(Completable.complete());
+        policy.onRequest(ctx).test().assertNoValues();
+
+        ((Maybe<Buffer>) onBodyCaptor.getValue().apply(Maybe.just(Buffer.buffer()))).test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertError(error -> {
+                assertThat(error).isInstanceOf(InterruptionFailureException.class);
+                InterruptionFailureException failureException = (InterruptionFailureException) error;
+                ExecutionFailure executionFailure = failureException.getExecutionFailure();
+                assertThat(executionFailure).isNotNull();
+                assertThat(executionFailure.key()).isEqualTo("GROOVY_EXECUTION_FAILURE");
+                assertThat(executionFailure.statusCode()).isEqualTo(INTERNAL_SERVER_ERROR_500);
+                return true;
+            });
+    }
+
     private static GroovyPolicyConfiguration buildConfig(String script) {
         return GroovyPolicyConfiguration.builder().script(loadScript(script)).readContent(true).build();
     }

--- a/src/test/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShellTest.java
+++ b/src/test/java/io/gravitee/policy/groovy/sandbox/SecuredGroovyShellTest.java
@@ -15,11 +15,18 @@
  */
 package io.gravitee.policy.groovy.sandbox;
 
+import static io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.SCRIPT_TIMEOUT_DEFAULT_SECONDS;
+import static io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.SCRIPT_TIMEOUT_MAX_SECONDS;
+import static io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.SCRIPT_TIMEOUT_MIN_SECONDS;
+import static io.gravitee.policy.groovy.sandbox.SecuredGroovyShell.SCRIPT_TIMEOUT_PROPERTY;
 import static io.gravitee.policy.groovy.sandbox.SecuredResolver.WHITELIST_LIST_KEY;
 import static io.gravitee.policy.groovy.sandbox.SecuredResolver.WHITELIST_MODE_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import groovy.lang.Binding;
+import java.util.concurrent.TimeoutException;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +50,104 @@ public class SecuredGroovyShellTest {
     public void init() {
         SecuredResolver.destroy();
         SecuredResolver.initialize(null);
+    }
+
+    @After
+    public void clearTimeoutProperty() {
+        System.clearProperty(SCRIPT_TIMEOUT_PROPERTY);
+    }
+
+    @Test
+    public void pen88ResolveScriptTimeoutReturnsDefaultWhenPropertyNotSet() {
+        System.clearProperty(SCRIPT_TIMEOUT_PROPERTY);
+        assertThat(SecuredGroovyShell.resolveScriptTimeoutSeconds()).isEqualTo(SCRIPT_TIMEOUT_DEFAULT_SECONDS);
+    }
+
+    @Test
+    public void pen88ResolveScriptTimeoutClampsToMinWhenValueTooLow() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "0");
+        assertThat(SecuredGroovyShell.resolveScriptTimeoutSeconds()).isEqualTo(SCRIPT_TIMEOUT_MIN_SECONDS);
+    }
+
+    @Test
+    public void pen88ResolveScriptTimeoutClampsToMaxWhenValueTooHigh() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "999");
+        assertThat(SecuredGroovyShell.resolveScriptTimeoutSeconds()).isEqualTo(SCRIPT_TIMEOUT_MAX_SECONDS);
+    }
+
+    @Test
+    public void pen88ResolveScriptTimeoutAcceptsValidValue() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "10");
+        assertThat(SecuredGroovyShell.resolveScriptTimeoutSeconds()).isEqualTo(10L);
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void pen88InfiniteLoopIsInterruptedByTimedInterrupt() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "1");
+        SecuredGroovyShell shell = new SecuredGroovyShell();
+        shell.evaluate("while (true) { /* spin */ }", new Binding());
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void pen88LongRunningLoopIsInterruptedByTimedInterrupt() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "1");
+        SecuredGroovyShell shell = new SecuredGroovyShell();
+        shell.evaluate("for (long i = 0; i < Long.MAX_VALUE; i++) {}", new Binding());
+    }
+
+    @Test
+    public void pen88LegitimateScriptCompletesWithinTimeout() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "5");
+        SecuredGroovyShell shell = new SecuredGroovyShell();
+        Object result = shell.evaluate("1 + 1", new Binding());
+        assertThat(result).isEqualTo(2);
+    }
+
+    private static final String SCRIPT_DECLARING_INTERFACE =
+        "interface Operators { Map OPERATORS = [eq: '='] }                 \n" +
+        "class Criteria implements Operators { String fieldName }          \n" +
+        "def criteria = new Criteria(fieldName: 'name')                    \n" +
+        "assert Operators.OPERATORS['eq'] == '='                           \n" +
+        "assert criteria.fieldName == 'name'                               \n" +
+        "assert criteria.OPERATORS['eq'] == '='";
+
+    @Test
+    public void scriptDeclaringInterfaceCompilesAndRunsByDefault() {
+        new SecuredGroovyShell().evaluate(SCRIPT_DECLARING_INTERFACE, new Binding());
+    }
+
+    @Test
+    public void scriptDeclaringAnnotationCompilesAndRunsByDefault() {
+        String script = "@interface Marker { }                             \n" + "assert 1 + 1 == 2";
+        new SecuredGroovyShell().evaluate(script, new Binding());
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void defaultModeKeepsInfiniteLoopInterruptedByTimedInterrupt() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "1");
+        String script = "interface Operators { Map OPERATORS = [eq: '='] } \n" + "while (true) { /* spin */ }";
+        new SecuredGroovyShell().evaluate(script, new Binding());
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void defaultModeKeepsInfiniteLoopInClassMethodInterruptedByTimedInterrupt() {
+        System.setProperty(SCRIPT_TIMEOUT_PROPERTY, "1");
+        String script =
+            "interface Operators { Map OPERATORS = [eq: '='] }             \n" +
+            "class Spinner implements Operators { def spin() { while (true) { } } }\n" +
+            "new Spinner().spin()";
+        new SecuredGroovyShell().evaluate(script, new Binding());
+    }
+
+    @Test
+    public void strictTimeoutDoesNotAffectRegularScripts() {
+        Object result = new SecuredGroovyShell(true).evaluate("1 + 1", new Binding());
+        assertThat(result).isEqualTo(2);
+    }
+
+    @Test(expected = MultipleCompilationErrorsException.class)
+    public void scriptDeclaringInterfaceFailsToCompileWithStrictTimeout() {
+        new SecuredGroovyShell(true).evaluate(SCRIPT_DECLARING_INTERFACE, new Binding());
     }
 
     @Test

--- a/src/test/resources/io/gravitee/policy/groovy/declare_interface.groovy
+++ b/src/test/resources/io/gravitee/policy/groovy/declare_interface.groovy
@@ -1,0 +1,7 @@
+interface Operators {
+    Map OPERATORS = [eq: '=']
+}
+
+if (Operators.OPERATORS['eq'] == '=') {
+    request.headers.remove 'x-context'
+}


### PR DESCRIPTION
**Issue**

Follow-up of https://gravitee.atlassian.net/browse/PEN-88 (reverted in 50ae720)

**Description**

Reintroduces the script execution timeout and off-event-loop execution from PEN-88, without the regression that motivated its revert: the `TimedInterrupt` instrumentation injects instance fields into every class of a script, which is illegal on interfaces, so any script declaring an `interface` (or an `@interface`) — valid Groovy that compiled fine before — failed with:

```
The field 'timedInterrupt...$expireTime' is not 'public static final' but is defined in interface '...'
```

Behavior:

- **Default (no breaking change)**: the timeout instrumentation is applied class by class and skips interfaces. Scripts declaring interfaces compile and run, and the execution timeout remains fully active on all instrumentable code (infinite loops at top level or in class methods are still interrupted — covered by tests).
- **`strictExecutionTimeout` policy option (opt-in, default `false`, improves security)**: rejects scripts that cannot be fully covered by the timeout instrumentation, guaranteeing that no part of the script (e.g. interface default methods or closures stored in interface constants) can escape the execution timeout. Exposed in `schema-form.json` and `schema-form-native-kafka.json`; configured per policy, no gateway restart needed.
- Strict and lenient modes use separate `SecuredGroovyShell` instances (lazily created for strict) so each keeps a coherent compiled-script cache.
- Restores the `junit-vintage-engine` test dependency removed by the revert: without it, the whole JUnit 4 `SecuredGroovyShellTest` suite is silently skipped (this is currently the case on master).

**Additional context**

- Reproduction: with PEN-88 applied, compile any script containing e.g. `interface Ops { Map OPERATORS = [eq: '='] }` — reported by a customer whose script declares interfaces as constant holders.
- Compatibility of the default mode was checked against a matrix of script constructs (interface constants, implemented interfaces, annotation definitions, enums, traits, inheritance, static methods, closures in fields, nested classes): everything that compiled before PEN-88 compiles; constructs that still fail (enum, trait, script-class inheritance) were already rejected by the groovy-sandbox before PEN-88.
- The console may need a follow-up to expose the `strictExecutionTimeout` toggle in the dedicated Groovy policy UI for HTTP APIs (other fields of `schema-form.json` are hidden and rendered by a custom UI); it renders out of the box for Native Kafka APIs and v2 APIs.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.4-fix-timed-interrupt-interface-compat-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-groovy/5.0.4-fix-timed-interrupt-interface-compat-SNAPSHOT/gravitee-policy-groovy-5.0.4-fix-timed-interrupt-interface-compat-SNAPSHOT.zip)
  <!-- Version placeholder end -->
